### PR TITLE
Link competition names to event pages on user profile

### DIFF
--- a/app/routes/users_.$id.tsx
+++ b/app/routes/users_.$id.tsx
@@ -1,5 +1,6 @@
 import { json, LoaderFunctionArgs, MetaFunction } from '@remix-run/node';
 import {
+  Link,
   ShouldRevalidateFunction,
   useLoaderData,
   useSearchParams,
@@ -137,6 +138,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
         createdAt,
         pointsGiven,
         competitionTitle,
+        competitionId,
         placement,
         imageUrl:
           metric === undefined
@@ -891,9 +893,20 @@ export default function UserById() {
                                         className="max-h-7 max-w-7 object-contain"
                                       />
                                     </Box>
-                                    <Text size="2" weight="medium">
-                                      {award.competitionTitle}
-                                    </Text>
+                                    {award.competitionId !== null ? (
+                                      <Link
+                                        to={`/events/${award.competitionId}`}
+                                        className="transition-colors hover:text-sanguine-red"
+                                      >
+                                        <Text size="2" weight="medium">
+                                          {award.competitionTitle}
+                                        </Text>
+                                      </Link>
+                                    ) : (
+                                      <Text size="2" weight="medium">
+                                        {award.competitionTitle}
+                                      </Text>
+                                    )}
                                   </Flex>
                                 </Table.Cell>
                                 <Table.Cell className="whitespace-nowrap">


### PR DESCRIPTION
Competition names in the Clan Points tab of the user profile now link to their `/events/{id}` page.

- The profile loader passes `competitionId` through in `competitionAwards` (it was already destructured, just not returned)
- Titles with a competition ID are wrapped in a `Link`, styled like other text links (`hover:text-sanguine-red`)
- Rows without an ID, including the rolled-up "Historical events" line, stay plain text

Lint and typecheck pass.