### PR TITLE
Add Sanguine Slayer page and profile section

### DIFF
--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -30,6 +30,13 @@ const topLinks = [
     label: 'PBs',
     match: (p: string) => p.startsWith('/personal-bests'),
   },
+  // The slayer grind is always on, so it sits with the other standing ladders
+  // rather than under Events (which is time-boxed competitions and their winners).
+  {
+    to: '/slayer',
+    label: 'Slayer',
+    match: (p: string) => p.startsWith('/slayer'),
+  },
 ];
 
 const topLinkClass = (active: boolean) =>
@@ -151,7 +158,9 @@ const Navbar = () => {
             delayDuration={100}
             className="mt-4 rounded-lg border border-gray-100 bg-gray-50 p-4 font-medium md:mt-0 md:border-0 md:bg-white md:p-0 dark:border-gray-700 dark:bg-gray-800 md:dark:bg-gray-900"
           >
-            <NavigationMenu.List className="m-0 flex list-none flex-col p-0 md:flex-row md:space-x-8 rtl:space-x-reverse">
+            {/* Seven items only just fit the md row — tighten the gap there and
+                give it back once there's room. */}
+            <NavigationMenu.List className="m-0 flex list-none flex-col p-0 md:flex-row md:space-x-5 lg:space-x-8 rtl:space-x-reverse">
               {topLinks.map(({ to, label, match }) => {
                 const active = match(location.pathname);
                 return (

--- a/app/components/route-skeleton-loader.tsx
+++ b/app/components/route-skeleton-loader.tsx
@@ -1,6 +1,6 @@
 import { useNavigation } from '@remix-run/react';
 import { useSpinDelay } from 'spin-delay';
-import { Container, Flex, Box, Card } from '@radix-ui/themes';
+import { Container, Flex, Box } from '@radix-ui/themes';
 import { useEffect } from 'react';
 
 function RouteSkeletonLoader() {
@@ -71,6 +71,11 @@ function RouteSkeletonLoader() {
       return <DropStatsSkeleton />;
     }
 
+    // Slayer page
+    if (targetPath === '/slayer') {
+      return <SlayerSkeleton />;
+    }
+
     // Collection log page
     if (targetPath === '/collection-log') {
       return <CollectionLogSkeleton />;
@@ -79,6 +84,16 @@ function RouteSkeletonLoader() {
     // Collection log category page (e.g., /collection-log/chambers_of_xeric)
     if (targetPath.match(/^\/collection-log\/[\w-]+$/)) {
       return <CollectionLogCategorySkeleton />;
+    }
+
+    // About page
+    if (targetPath === '/about') {
+      return <AboutSkeleton />;
+    }
+
+    // Home page
+    if (targetPath === '/') {
+      return <HomeSkeleton />;
     }
 
     // Generic fallback for other pages
@@ -147,14 +162,7 @@ function EventsListSkeleton() {
   return (
     <Container size="3" className="min-h-full py-6">
       <Flex direction="column">
-        {/* Page header */}
-        <Box mb="6">
-          <Flex align="center" gap="3">
-            <div className="h-11 w-11 animate-pulse rounded-sm bg-gray-800/50"></div>
-            <div className="h-9 w-40 animate-pulse rounded-sm bg-gray-800/50"></div>
-          </Flex>
-          <div className="mt-3 h-4 w-72 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
-        </Box>
+        <SkeletonPageHeader titleWidth="w-40" summaryWidth="w-72" />
 
         {/* Column header + rows */}
         <div className="border-b border-t-2 border-gray-700 border-t-sanguine-red py-2.5">
@@ -184,14 +192,7 @@ function UsersListSkeleton() {
   return (
     <Container size="3" className="min-h-full py-6">
       <Flex direction="column">
-        {/* Page header */}
-        <Box mb="6">
-          <Flex align="center" gap="3">
-            <div className="h-11 w-11 animate-pulse rounded-sm bg-gray-800/50"></div>
-            <div className="h-9 w-48 animate-pulse rounded-sm bg-gray-800/50"></div>
-          </Flex>
-          <div className="mt-3 h-4 w-80 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
-        </Box>
+        <SkeletonPageHeader titleWidth="w-48" summaryWidth="w-80" />
 
         {/* Leader band */}
         <Box
@@ -343,14 +344,7 @@ function DropsPageSkeleton() {
   return (
     <Container size="3" className="min-h-full py-6">
       <Flex direction="column">
-        {/* Page header */}
-        <Box mb="6">
-          <Flex align="center" gap="3">
-            <div className="h-11 w-11 animate-pulse rounded-sm bg-gray-800/50"></div>
-            <div className="h-9 w-44 animate-pulse rounded-sm bg-gray-800/50"></div>
-          </Flex>
-          <div className="mt-3 h-4 w-80 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
-        </Box>
+        <SkeletonPageHeader titleWidth="w-44" summaryWidth="w-80" />
 
         {/* Drop log rows */}
         <Box className="border-t-2 border-t-sanguine-red">
@@ -386,14 +380,7 @@ function MonthlyWinnersSkeleton() {
   return (
     <Container size="3" className="min-h-full py-6">
       <Flex direction="column">
-        {/* Page header */}
-        <Box mb="6">
-          <Flex align="center" gap="3">
-            <div className="h-11 w-11 animate-pulse rounded-sm bg-gray-800/50"></div>
-            <div className="h-9 w-64 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
-          </Flex>
-          <div className="mt-3 h-4 w-96 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
-        </Box>
+        <SkeletonPageHeader titleWidth="w-64" />
 
         {/* Reigning champions band */}
         <Box
@@ -461,14 +448,7 @@ function PersonalBestsSkeleton() {
   return (
     <Container size="3" className="min-h-full py-6">
       <Flex direction="column">
-        {/* Page header */}
-        <Box mb="6">
-          <Flex align="center" gap="3">
-            <div className="h-11 w-11 animate-pulse rounded-sm bg-gray-800/50"></div>
-            <div className="h-9 w-56 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
-          </Flex>
-          <div className="mt-3 h-4 w-96 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
-        </Box>
+        <SkeletonPageHeader titleWidth="w-56" />
 
         {/* Toolbar */}
         <Flex gap="2" align="center" className="mb-2">
@@ -514,14 +494,7 @@ function DropStatsSkeleton() {
   return (
     <Container size="3" className="min-h-full py-6">
       <Flex direction="column">
-        {/* Page header */}
-        <Box mb="6">
-          <Flex align="center" gap="3">
-            <div className="h-11 w-11 animate-pulse rounded-sm bg-gray-800/50"></div>
-            <div className="h-9 w-60 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
-          </Flex>
-          <div className="mt-3 h-4 w-96 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
-        </Box>
+        <SkeletonPageHeader titleWidth="w-60" />
 
         {/* Chip toolbar */}
         <Flex gap="2" align="center" wrap="wrap" className="mb-6">
@@ -543,9 +516,15 @@ function DropStatsSkeleton() {
   );
 }
 
-// Shared ghost blocks for the collection log skeletons. (Older skeletons
-// predate these and can migrate opportunistically.)
-function SkeletonPageHeader({ titleWidth }: { titleWidth: string }) {
+// Shared ghost blocks: the icon-and-title page header and h2 section rule
+// every list page opens with.
+function SkeletonPageHeader({
+  titleWidth,
+  summaryWidth = 'w-96',
+}: {
+  titleWidth: string;
+  summaryWidth?: string;
+}) {
   return (
     <Box mb="6">
       <Flex align="center" gap="3">
@@ -554,7 +533,9 @@ function SkeletonPageHeader({ titleWidth }: { titleWidth: string }) {
           className={`h-9 ${titleWidth} max-w-full animate-pulse rounded-sm bg-gray-800/50`}
         ></div>
       </Flex>
-      <div className="mt-3 h-4 w-96 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
+      <div
+        className={`mt-3 h-4 ${summaryWidth} max-w-full animate-pulse rounded-sm bg-gray-800/50`}
+      ></div>
     </Box>
   );
 }
@@ -679,6 +660,122 @@ function CollectionLogSkeleton() {
   );
 }
 
+// Slayer Skeleton — mirrors the task log: header, the two-column leader band,
+// then the task table and the completions feed either side of the red rule.
+function SlayerSkeleton() {
+  return (
+    <Container size="4" className="min-h-full py-6">
+      <Flex direction="column">
+        <SkeletonPageHeader titleWidth="w-40" />
+
+        {/* Leader band */}
+        <Box
+          mb="6"
+          className="border-b border-t-2 border-gray-800 border-t-sanguine-red"
+        >
+          <div className="grid grid-cols-1 sm:grid-cols-2">
+            {[0, 1].map(col => (
+              <div
+                key={col}
+                className={
+                  col > 0
+                    ? 'border-t border-gray-800 pb-2 sm:border-l sm:border-t-0 sm:pl-5'
+                    : 'pb-2 sm:pr-5'
+                }
+              >
+                <div className="mb-2 mt-2 h-3 w-36 animate-pulse rounded-sm bg-gray-800/50"></div>
+                {[...Array(3)].map((_, idx) => (
+                  <Flex key={idx} align="center" gap="3" className="py-1.5">
+                    <div className="h-4 w-5 shrink-0 animate-pulse rounded-sm bg-gray-800/50"></div>
+                    <div className="h-[22px] w-[22px] shrink-0 animate-pulse rounded-sm bg-gray-800/50"></div>
+                    <div
+                      className={`h-4 flex-1 animate-pulse rounded-sm bg-gray-800/50 ${idx === 0 ? 'h-5' : ''}`}
+                    ></div>
+                    <div className="h-4 w-12 animate-pulse rounded-sm bg-gray-800/50"></div>
+                  </Flex>
+                ))}
+              </div>
+            ))}
+          </div>
+        </Box>
+
+        {/* Task log and completions, split by the red column divider */}
+        <div className="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:gap-0 lg:divide-x-2 lg:divide-sanguine-red">
+          <Box className="lg:pr-8">
+            <SkeletonSectionHeading titleWidth="w-28" />
+            <Box mt="2">
+              {[...Array(10)].map((_, idx) => (
+                <Flex
+                  key={idx}
+                  align="center"
+                  gap="3"
+                  className={`px-2 py-2 ${idx % 2 === 1 ? 'bg-sanguine-red/[0.05]' : ''}`}
+                >
+                  <div className="h-4 w-6 shrink-0 animate-pulse rounded-sm bg-gray-800/50"></div>
+                  <div className="h-[22px] w-[22px] shrink-0 animate-pulse rounded-sm bg-gray-800/50"></div>
+                  <div className="min-w-0 flex-1 space-y-1.5">
+                    <div className="h-4 w-32 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
+                    <div className="h-3 w-24 animate-pulse rounded-sm bg-gray-800/40"></div>
+                  </div>
+                  <div className="h-4 w-8 animate-pulse rounded-sm bg-gray-800/50"></div>
+                  <div className="h-4 w-10 animate-pulse rounded-sm bg-gray-800/50"></div>
+                  <div className="hidden h-4 w-16 animate-pulse rounded-sm bg-gray-800/40 md:block"></div>
+                </Flex>
+              ))}
+            </Box>
+          </Box>
+          <Box className="hidden lg:block lg:pl-8">
+            <SkeletonSectionHeading titleWidth="w-36" />
+            <Box mt="2">
+              {[...Array(10)].map((_, idx) => (
+                <Flex
+                  key={idx}
+                  align="center"
+                  gap="3"
+                  className={`border-b border-gray-800 px-2 py-2 ${idx % 2 === 1 ? 'bg-sanguine-red/[0.05]' : ''}`}
+                >
+                  <div className="h-7 w-7 shrink-0 animate-pulse rounded-sm bg-gray-800/50"></div>
+                  <div className="min-w-0 flex-1 space-y-1.5">
+                    <div className="h-4 w-40 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
+                    <div className="h-3 w-28 animate-pulse rounded-sm bg-gray-800/40"></div>
+                  </div>
+                  <div className="space-y-1.5">
+                    <div className="ml-auto h-3 w-12 animate-pulse rounded-sm bg-gray-800/40"></div>
+                    <div className="ml-auto h-4 w-16 animate-pulse rounded-sm bg-gray-800/50"></div>
+                  </div>
+                </Flex>
+              ))}
+            </Box>
+          </Box>
+        </div>
+
+        {/* How it works: heading rule, prose lines, then the command rows */}
+        <Box mt="9">
+          <SkeletonSectionHeading titleWidth="w-40" />
+          <div className="mt-3 space-y-2.5">
+            <div className="h-4 w-full animate-pulse rounded-sm bg-gray-800/50"></div>
+            <div className="h-4 w-11/12 animate-pulse rounded-sm bg-gray-800/50"></div>
+            <div className="h-4 w-3/4 animate-pulse rounded-sm bg-gray-800/50"></div>
+          </div>
+          <Box mt="4" className="border-t-2 border-t-sanguine-red">
+            {[...Array(3)].map((_, idx) => (
+              <Flex
+                key={idx}
+                align="center"
+                gap="3"
+                className={`border-b border-gray-800 px-2 py-2 ${idx % 2 === 1 ? 'bg-sanguine-red/[0.05]' : ''}`}
+              >
+                <div className="h-4 w-32 shrink-0 animate-pulse rounded-sm bg-gray-800/50"></div>
+                <div className="h-4 w-52 max-w-full animate-pulse rounded-sm bg-gray-800/40"></div>
+              </Flex>
+            ))}
+          </Box>
+        </Box>
+      </Flex>
+    </Container>
+  );
+}
+
 // Collection Log Category Skeleton — mirrors the log book: header, a tile
 // grid of ghost items, then collector rows with wrapped loot-shelf ghosts.
 function CollectionLogCategorySkeleton() {
@@ -730,17 +827,150 @@ function CollectionLogCategorySkeleton() {
   );
 }
 
-// Generic Skeleton for unknown routes
+// Home Skeleton — mirrors the front page: hero (icon + title over prose and
+// the banner), then the two-column noticeboard of heading rules and rows.
+function HomeSkeleton() {
+  return (
+    <Container size="3" className="min-h-full py-6">
+      {/* Hero */}
+      <Box mt="4">
+        <Flex align="center" gap="3">
+          <div className="h-11 w-11 animate-pulse rounded-sm bg-gray-800/50"></div>
+          <div className="h-9 w-44 animate-pulse rounded-sm bg-gray-800/50"></div>
+        </Flex>
+        <div className="mt-4 max-w-3xl space-y-2.5">
+          <div className="h-4 w-full animate-pulse rounded-sm bg-gray-800/50"></div>
+          <div className="h-4 w-11/12 animate-pulse rounded-sm bg-gray-800/50"></div>
+          <div className="h-4 w-2/3 animate-pulse rounded-sm bg-gray-800/50"></div>
+        </div>
+        <div className="mt-6 h-40 w-full animate-pulse rounded-sm bg-gray-800/30 sm:h-56"></div>
+      </Box>
+
+      {/* Noticeboard columns */}
+      <div className="mt-10 grid grid-cols-1 gap-10 lg:grid-cols-2 lg:gap-x-8">
+        <Box>
+          <SkeletonSectionHeading titleWidth="w-32" />
+          <Box mt="2">
+            {[...Array(5)].map((_, idx) => (
+              <Flex
+                key={idx}
+                align="center"
+                gap="3"
+                className={`px-2 py-2.5 ${idx % 2 === 1 ? 'bg-sanguine-red/[0.05]' : ''}`}
+              >
+                <div className="h-6 w-6 shrink-0 animate-pulse rounded-sm bg-gray-800/50"></div>
+                <div className="h-4 max-w-56 flex-1 animate-pulse rounded-sm bg-gray-800/50"></div>
+              </Flex>
+            ))}
+          </Box>
+        </Box>
+        <Box>
+          {[0, 1].map(section => (
+            <Box key={section} className={section > 0 ? 'mt-10' : undefined}>
+              <SkeletonSectionHeading titleWidth="w-40" />
+              <Box mt="2">
+                {[...Array(3)].map((_, idx) => (
+                  <Flex
+                    key={idx}
+                    align="center"
+                    gap="3"
+                    className={`px-2 py-2.5 ${idx % 2 === 1 ? 'bg-sanguine-red/[0.05]' : ''}`}
+                  >
+                    <div className="h-6 w-6 shrink-0 animate-pulse rounded-sm bg-gray-800/50"></div>
+                    <div className="h-4 max-w-56 flex-1 animate-pulse rounded-sm bg-gray-800/50"></div>
+                  </Flex>
+                ))}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </div>
+    </Container>
+  );
+}
+
+// About Skeleton — mirrors the about page: title over a plain subtitle,
+// right-hand infobox with its red band, prose lede, then ruled sections
+// of list rows.
+function AboutSkeleton() {
+  return (
+    <Container size="4" className="min-h-full py-6">
+      <Box mt="2">
+        <div className="h-10 w-72 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
+        <div className="mt-3 h-4 w-80 max-w-full animate-pulse rounded-sm bg-gray-800/40"></div>
+      </Box>
+
+      <div className="flex flex-col gap-6 lg:flex-row-reverse lg:gap-8">
+        {/* Infobox */}
+        <aside className="mt-6 w-full shrink-0 self-start border border-gray-700 lg:w-80">
+          <div className="h-9 animate-pulse bg-sanguine-red/40"></div>
+          <Flex align="center" justify="center" className="py-5">
+            <div className="h-14 w-14 animate-pulse rounded-sm bg-gray-800/50"></div>
+          </Flex>
+          {[...Array(6)].map((_, idx) => (
+            <div
+              key={idx}
+              className="grid grid-cols-[6.5rem_1fr] gap-x-3 border-t border-gray-800 px-3 py-2.5"
+            >
+              <div className="h-4 w-20 animate-pulse rounded-sm bg-gray-800/40"></div>
+              <div className="h-4 w-28 animate-pulse rounded-sm bg-gray-800/50"></div>
+            </div>
+          ))}
+        </aside>
+
+        <Box className="min-w-0 flex-1">
+          {/* Lede */}
+          <div className="mt-6 space-y-2.5">
+            <div className="h-4 w-full animate-pulse rounded-sm bg-gray-800/50"></div>
+            <div className="h-4 w-11/12 animate-pulse rounded-sm bg-gray-800/50"></div>
+            <div className="h-4 w-3/4 animate-pulse rounded-sm bg-gray-800/50"></div>
+          </div>
+
+          {/* Ruled sections of list rows */}
+          {[0, 1].map(section => (
+            <Box key={section} className="mt-10">
+              <SkeletonSectionHeading titleWidth="w-40" />
+              <Box mt="3" className="max-w-2xl">
+                {[...Array(4)].map((_, idx) => (
+                  <div
+                    key={idx}
+                    className={`px-2 py-1.5 ${idx % 2 === 1 ? 'bg-sanguine-red/[0.05]' : ''}`}
+                  >
+                    <div
+                      className={`h-4 animate-pulse rounded-sm bg-gray-800/50 ${idx % 2 === 0 ? 'w-64' : 'w-52'} max-w-full`}
+                    ></div>
+                  </div>
+                ))}
+              </Box>
+            </Box>
+          ))}
+        </Box>
+      </div>
+    </Container>
+  );
+}
+
+// Generic Skeleton for unknown routes — flat and square like everything else:
+// a ghost page header over one committed red rule and zebra rows.
 function GenericSkeleton() {
   return (
-    <Container size="4" className="min-h-full py-8">
-      <Flex direction="column" gap="6">
-        <Card className="border border-gray-800 bg-gray-900">
-          <Box p="5">
-            <div className="mb-4 h-6 w-48 animate-pulse rounded bg-gray-800/50"></div>
-            <div className="h-64 animate-pulse rounded bg-gray-800/30"></div>
-          </Box>
-        </Card>
+    <Container size="3" className="min-h-full py-6">
+      <Flex direction="column">
+        <SkeletonPageHeader titleWidth="w-52" summaryWidth="w-80" />
+        <Box className="border-t-2 border-t-sanguine-red">
+          {[...Array(8)].map((_, idx) => (
+            <Flex
+              key={idx}
+              align="center"
+              gap="3"
+              className={`border-b border-gray-800 px-2 py-3 ${idx % 2 === 1 ? 'bg-sanguine-red/[0.05]' : ''}`}
+            >
+              <div className="h-6 w-6 shrink-0 animate-pulse rounded-sm bg-gray-800/50"></div>
+              <div className="h-4 w-64 max-w-full flex-1 animate-pulse rounded-sm bg-gray-800/50"></div>
+              <div className="h-4 w-16 animate-pulse rounded-sm bg-gray-800/40"></div>
+            </Flex>
+          ))}
+        </Box>
       </Flex>
     </Container>
   );

--- a/app/data/slayer/index.ts
+++ b/app/data/slayer/index.ts
@@ -1,0 +1,40 @@
+import { prisma } from '~/utils/db.server';
+
+// Sanguine Slayer rows, written by the Discord bot (which calls the feature the Boss Wheel).
+// A WheelEvents row configures one instance of the feature; its window lives on the sibling
+// BOSS_WHEEL ClanEvents row. Spins are the task log: one document per assigned task.
+
+export const SPIN_STATUS = {
+  ACTIVE: 'ACTIVE',
+  COMPLETED: 'COMPLETED',
+  REPLACED: 'REPLACED',
+  EXPIRED: 'EXPIRED',
+} as const;
+
+export const getWheelConfigs = () => prisma.wheelEvents.findMany();
+
+export const getWheelClanEvents = () =>
+  prisma.clanEvents.findMany({ where: { type: 'BOSS_WHEEL' } });
+
+/** Completed tasks across every instance — the all-time task log. */
+export const getCompletedSpins = () =>
+  prisma.wheelSpins.findMany({ where: { status: SPIN_STATUS.COMPLETED } });
+
+/** Tasks members are out on right now (callers filter to the live instance). */
+export const getActiveSpins = () =>
+  prisma.wheelSpins.findMany({ where: { status: SPIN_STATUS.ACTIVE } });
+
+/** Every spin one member has ever been assigned, completed or not. */
+export const getSpinsForDiscordId = (discordId: string) =>
+  prisma.wheelSpins.findMany({ where: { discordId } });
+
+/** How many tasks have been handed out in total, by what became of them. */
+export const getSpinCountsByStatus = async (): Promise<
+  Record<string, number>
+> => {
+  const rows = await prisma.wheelSpins.groupBy({
+    by: ['status'],
+    _count: { _all: true },
+  });
+  return Object.fromEntries(rows.map(row => [row.status, row._count._all]));
+};

--- a/app/mocks/fixtures.server.ts
+++ b/app/mocks/fixtures.server.ts
@@ -52,12 +52,20 @@ export type MockUser = {
 };
 
 const buildUsers = (): MockUser[] => {
+  // Real Sanguine rank names — anything else has no icon under /rank-icons.
   const roles = [
     'Owner',
     'Deputy_owner',
-    'Coordinator',
-    'Officer',
-    'Member',
+    'Administrator',
+    'Moderator',
+    'Blood',
+    'Wrath',
+    'Hellcat',
+    'Beast',
+    'Myth',
+    'Legend',
+    'Sage',
+    'Natural',
     'Guest',
   ];
   return Array.from({ length: 30 }, (_, i) => {
@@ -140,7 +148,34 @@ const buildDrops = (): MockDrop[] => {
   }).sort((a, b) => b.createdAt.localeCompare(a.createdAt));
 };
 
-export const MOCK_DROPS: MockDrop[] = buildDrops();
+// Clan-bucket audits so the profile's Clan points section has more than one source to divide
+// (drops alone never exercise its subsections).
+const buildClanAudits = (): MockDrop[] =>
+  MOCK_USERS.slice(0, 12).flatMap(user =>
+    Array.from(
+      { length: faker.number.int({ min: 1, max: 4 }) },
+      (): MockDrop => ({
+        id: faker.string.hexadecimal({ length: 24, casing: 'lower' }).slice(2),
+        v: 0,
+        createdAt: faker.date
+          .between({ from: '2025-01-01', to: '2026-08-01' })
+          .toISOString(),
+        destinationDiscordId: user.discordId,
+        sourceDiscordId: faker.string.numeric(18),
+        messageId: faker.string.numeric(18),
+        pointsGiven: faker.number.int({ min: 3, max: 20 }),
+        type: faker.helpers.weightedArrayElement([
+          { value: 'COMPETITION', weight: 4 },
+          { value: 'CLAN_MANUAL', weight: 1 },
+        ]),
+        itemId: null,
+        bossName: null,
+        osrsName: null,
+      }),
+    ),
+  );
+
+export const MOCK_DROPS: MockDrop[] = [...buildDrops(), ...buildClanAudits()];
 
 export type MockMonthlyWinner = {
   eventId: string;
@@ -187,6 +222,223 @@ const buildMonthlyWinners = (): MockMonthlyWinner[] => {
 };
 
 export const MOCK_MONTHLY_WINNERS: MockMonthlyWinner[] = buildMonthlyWinners();
+
+// ---- Sanguine Slayer ----
+
+// Real WOM metric slugs and the display names the bot spins them with, so mocked tasks resolve
+// to the same wiki thumbnails production does.
+const SLAYER_BOSSES: [metric: string, displayName: string][] = [
+  ['vorkath', 'Vorkath'],
+  ['zulrah', 'Zulrah'],
+  ['cerberus', 'Cerberus'],
+  ['general_graardor', 'General Graardor'],
+  ['kreearra', "Kree'Arra"],
+  ['the_whisperer', 'The Whisperer'],
+  ['vardorvis', 'Vardorvis'],
+  ['nex', 'Nex'],
+  ['araxxor', 'Araxxor'],
+  ['duke_sucellus', 'Duke Sucellus'],
+  ['alchemical_hydra', 'Alchemical Hydra'],
+  ['phosanis_nightmare', "Phosani's Nightmare"],
+  ['barrows_chests', 'Barrows Chests'],
+  ['scurrius', 'Scurrius'],
+  ['yama', 'Yama'],
+  ['chambers_of_xeric', 'Chambers Of Xeric'],
+];
+
+const objectId = () =>
+  faker.string.hexadecimal({ length: 24, casing: 'lower' }).slice(2);
+
+const STANDING_CLAN_EVENT_ID = objectId();
+const EVENT_CLAN_EVENT_ID = objectId();
+
+export const MOCK_WHEEL_CLAN_EVENTS = [
+  {
+    id: STANDING_CLAN_EVENT_ID,
+    v: 0,
+    type: 'BOSS_WHEEL',
+    startDate: '2026-05-01T00:00:00.000Z',
+    endDate: '2126-05-01T00:00:00.000Z',
+    winnerDiscordId: null,
+    winnerOsrsName: null,
+  },
+  {
+    id: EVENT_CLAN_EVENT_ID,
+    v: 0,
+    type: 'BOSS_WHEEL',
+    startDate: '2026-07-06T00:00:00.000Z',
+    endDate: '2026-07-13T00:00:00.000Z',
+    winnerDiscordId: MOCK_USERS[3].discordId,
+    winnerOsrsName: MOCK_USERS[3].nickname,
+  },
+];
+
+export const MOCK_WHEELS = [
+  {
+    id: objectId(),
+    v: 0,
+    clanEventId: STANDING_CLAN_EVENT_ID,
+    mode: 'STANDING',
+    name: 'Sanguine Slayer',
+    multiplier: 1,
+    taskClanPoints: 5,
+    startingRerolls: 3,
+    rerollEarnRate: 0.3,
+    respinCooldownHours: 8,
+    prizePoints: { first: 0, second: 0, third: 0, participant: 0 },
+    bossPool: SLAYER_BOSSES.map(([metric]) => metric),
+    createdByDiscordId: MOCK_USERS[0].discordId,
+    createdAt: '2026-05-01T00:00:00.000Z',
+  },
+  {
+    id: objectId(),
+    v: 0,
+    clanEventId: EVENT_CLAN_EVENT_ID,
+    mode: 'EVENT',
+    name: 'July Slayer Sprint',
+    multiplier: 2,
+    taskClanPoints: 0,
+    startingRerolls: 3,
+    rerollEarnRate: 0.3,
+    respinCooldownHours: 8,
+    prizePoints: { first: 20, second: 15, third: 10, participant: 3 },
+    bossPool: SLAYER_BOSSES.map(([metric]) => metric),
+    createdByDiscordId: MOCK_USERS[0].discordId,
+    createdAt: '2026-07-06T00:00:00.000Z',
+  },
+];
+
+export type MockSpin = {
+  id: string;
+  v: number;
+  clanEventId: string;
+  discordId: string;
+  task: {
+    type: string;
+    bossMetric: string;
+    bossDisplayName: string;
+    dinkNames: string[];
+    itemFilter: { mode: string; itemIds: number[] };
+  };
+  spinType: string;
+  status: string;
+  spunAt: string;
+  completion: {
+    itemId: number;
+    itemName: string;
+    dropPoints: number;
+    bonusPoints: number;
+    eventPoints: number;
+    taskClanPoints: number;
+    bossNameRaw: string;
+    osrsName: string | null;
+    dropMessageId: string;
+    completedAt: string;
+  } | null;
+};
+
+const buildSpin = (
+  clanEventId: string,
+  user: MockUser,
+  status: string,
+  spunAt: Date,
+  {
+    multiplier,
+    taskClanPoints,
+  }: { multiplier: number; taskClanPoints: number },
+): MockSpin => {
+  const [bossMetric, bossDisplayName] =
+    faker.helpers.arrayElement(SLAYER_BOSSES);
+  const useAlt = user.alts.length > 0 && faker.datatype.boolean(0.25);
+  const dropPoints = faker.number.int({ min: 1, max: 90 });
+  const completedAt = new Date(
+    spunAt.getTime() + faker.number.int({ min: 1, max: 40 }) * 3_600_000,
+  );
+  return {
+    id: objectId(),
+    v: 0,
+    clanEventId,
+    discordId: user.discordId,
+    task: {
+      type: 'BOSS_DROP',
+      bossMetric,
+      bossDisplayName,
+      dinkNames: [bossDisplayName.toLowerCase()],
+      itemFilter: { mode: 'ANY', itemIds: [] },
+    },
+    spinType: faker.helpers.arrayElement(['INITIAL', 'FREE_RESPIN', 'REROLL']),
+    status,
+    spunAt: spunAt.toISOString(),
+    completion:
+      status === 'COMPLETED'
+        ? {
+            itemId: faker.number.int({ min: 1, max: 30000 }),
+            itemName: faker.commerce.productName(),
+            dropPoints,
+            bonusPoints: Math.round(dropPoints * (multiplier - 1)),
+            eventPoints: Math.round(dropPoints * multiplier),
+            taskClanPoints,
+            bossNameRaw: bossDisplayName.toLowerCase(),
+            osrsName: useAlt
+              ? faker.helpers.arrayElement(user.alts).altName
+              : null,
+            dropMessageId: faker.string.numeric(18),
+            completedAt: completedAt.toISOString(),
+          }
+        : null,
+  };
+};
+
+const buildSpins = (): MockSpin[] => {
+  // The standing grind: most members have completed a handful, a dozen are out on task now,
+  // and plenty of tasks were skipped along the way.
+  const grinders = MOCK_USERS.slice(0, 22);
+  const standing = grinders.flatMap((user, index) =>
+    Array.from(
+      { length: faker.number.int({ min: 0, max: index < 6 ? 11 : 5 }) },
+      () =>
+        buildSpin(
+          STANDING_CLAN_EVENT_ID,
+          user,
+          faker.helpers.weightedArrayElement([
+            { value: 'COMPLETED', weight: 6 },
+            { value: 'REPLACED', weight: 3 },
+          ]),
+          faker.date.between({ from: '2026-05-02', to: '2026-08-04' }),
+          { multiplier: 1, taskClanPoints: 5 },
+        ),
+    ),
+  );
+  const outOnTask = faker.helpers
+    .arrayElements(grinders, 11)
+    .map(user =>
+      buildSpin(
+        STANDING_CLAN_EVENT_ID,
+        user,
+        'ACTIVE',
+        faker.date.between({ from: '2026-08-04', to: '2026-08-06' }),
+        { multiplier: 1, taskClanPoints: 5 },
+      ),
+    );
+  // The July competition: double points, no per-task clan points, all long since finished.
+  const sprint = faker.helpers.arrayElements(MOCK_USERS, 9).flatMap(user =>
+    Array.from({ length: faker.number.int({ min: 1, max: 4 }) }, () =>
+      buildSpin(
+        EVENT_CLAN_EVENT_ID,
+        user,
+        faker.helpers.weightedArrayElement([
+          { value: 'COMPLETED', weight: 5 },
+          { value: 'EXPIRED', weight: 1 },
+        ]),
+        faker.date.between({ from: '2026-07-06', to: '2026-07-12' }),
+        { multiplier: 2, taskClanPoints: 0 },
+      ),
+    ),
+  );
+  return [...standing, ...outOnTask, ...sprint];
+};
+
+export const MOCK_SPINS: MockSpin[] = buildSpins();
 
 export type MockCompetition = {
   id: number;

--- a/app/mocks/slayer/index.ts
+++ b/app/mocks/slayer/index.ts
@@ -1,0 +1,36 @@
+import {
+  MOCK_SPINS,
+  MOCK_WHEEL_CLAN_EVENTS,
+  MOCK_WHEELS,
+} from '~/mocks/fixtures.server';
+
+export const SPIN_STATUS = {
+  ACTIVE: 'ACTIVE',
+  COMPLETED: 'COMPLETED',
+  REPLACED: 'REPLACED',
+  EXPIRED: 'EXPIRED',
+} as const;
+
+export const getWheelConfigs = async () => MOCK_WHEELS;
+
+export const getWheelClanEvents = async () => MOCK_WHEEL_CLAN_EVENTS;
+
+export const getCompletedSpins = async () =>
+  MOCK_SPINS.filter(spin => spin.status === SPIN_STATUS.COMPLETED);
+
+export const getActiveSpins = async () =>
+  MOCK_SPINS.filter(spin => spin.status === SPIN_STATUS.ACTIVE);
+
+export const getSpinsForDiscordId = async (discordId: string) =>
+  MOCK_SPINS.filter(spin => spin.discordId === discordId);
+
+export const getSpinCountsByStatus = async (): Promise<
+  Record<string, number>
+> =>
+  MOCK_SPINS.reduce<Record<string, number>>(
+    (counts, spin) => ({
+      ...counts,
+      [spin.status]: (counts[spin.status] ?? 0) + 1,
+    }),
+    {},
+  );

--- a/app/routes/about.tsx
+++ b/app/routes/about.tsx
@@ -38,12 +38,14 @@ export async function loader() {
 
 const PVM_CONTENT = ['ToB / ToB HM', 'CoX / CoX CM', 'ToA', 'Nex'];
 
-const COMMUNITY_EVENTS = [
-  ['Weekly competitions', 'boss and skill challenges'],
-  ['Bingo events', 'varied challenges and rewards'],
+// The third entry links the activity's page, where it has one.
+const CLAN_ACTIVITIES: [name: string, detail: string, to?: string][] = [
+  ['Sanguine Slayer', 'a boss task on demand, any day of the week', '/slayer'],
+  ['Weekly competitions', 'boss and skill challenges', '/events'],
+  ['Bingo events', 'varied challenges and rewards', '/bingo'],
   ['Inter-clan events', 'compete with other clans'],
   ['Active Discord', 'cc chatter, raid pings, and event signups'],
-] as const;
+];
 
 const listItemClass = `px-2 py-1 ${zebraStripeClass}`;
 
@@ -128,6 +130,17 @@ export default function AboutRoute() {
             </Link>{' '}
             and bingo events.
           </Text>
+          <Text as="p" size="3" className="mt-3 leading-7 text-gray-300">
+            Between the raids there is{' '}
+            <Link to="/slayer" className={proseLinkClass}>
+              Sanguine Slayer
+            </Link>
+            , our own Slayer Master: ask for a task, get a random boss, and any
+            drop from it that is worth{' '}
+            <span className="text-white">drop points</span> completes the task
+            and pays <span className="text-osrs-gold">clan points</span> on top.
+            No signup, no schedule, and the bot spots the drop for you.
+          </Text>
 
           {/* What we offer */}
           <section className="mt-10">
@@ -146,12 +159,20 @@ export default function AboutRoute() {
                 </ul>
               </Box>
               <Box className="min-w-0">
-                <SubsectionHeading title="Community events" />
+                {/* "Activities", not "events" — the slayer grind and the
+                    Discord are always on, not scheduled. */}
+                <SubsectionHeading title="Clan activities" />
                 <ul>
-                  {COMMUNITY_EVENTS.map(([name, detail]) => (
+                  {CLAN_ACTIVITIES.map(([name, detail, to]) => (
                     <li key={name} className={listItemClass}>
                       <Text size="3" className="text-gray-300">
-                        <span className="text-white">{name}</span>
+                        {to ? (
+                          <Link to={to} className={proseLinkClass}>
+                            {name}
+                          </Link>
+                        ) : (
+                          <span className="text-white">{name}</span>
+                        )}
                         <span className="text-gray-400"> · {detail}</span>
                       </Text>
                     </li>

--- a/app/routes/slayer.tsx
+++ b/app/routes/slayer.tsx
@@ -1,0 +1,698 @@
+import { json, MetaFunction } from '@remix-run/node';
+import { Link, useLoaderData, useNavigate } from '@remix-run/react';
+import { useState } from 'react';
+import dayjs from 'dayjs';
+import { Box, Container, Flex, Text } from '@radix-ui/themes';
+import { getSlayerLog } from '~/services/slayer-service.server';
+import { getUsersWithNicknames } from '~/services/sanguine-service.server';
+import { getClanFromWom } from '~/services/wom-api-service.server';
+import { fetchRankImage, rankLabel } from '~/utils/clan-ranks';
+import { PageHeader } from '~/components/PageHeader';
+import { LeaderBand, ILeaderBoard } from '~/components/LeaderBand';
+import { SectionHeading } from '~/components/SectionHeading';
+import { SortableHeaderButton } from '~/components/SortableHeaderButton';
+import { CoinsIcon } from '~/components/CoinsIcon';
+import { EmptyState } from '~/components/EmptyState';
+import { Pagination } from '~/components/Pagination';
+import {
+  proseLinkClass,
+  zebraRowClass,
+  zebraStripeClass,
+} from '~/utils/styles';
+import { formatGp, SLAYER_ICON, WHEEL_MODE } from '~/utils/slayer';
+import { usePagination } from '~/utils/use-pagination';
+
+type SortField = 'tasks' | 'name' | 'clanPoints' | 'bonusPoints' | 'loot';
+type SortDirection = 'asc' | 'desc';
+
+// Columns that only fit once the table has the full page width (md) or the wide split (xl).
+const WIDE_COLUMN_CLASS = 'hidden justify-end md:flex lg:hidden xl:flex';
+const WIDE_CELL_CLASS = 'hidden md:block lg:hidden xl:block';
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'Sanguine Slayer' },
+    {
+      name: 'description',
+      content:
+        'The Sanguine Slayer task log: boss tasks assigned, the drops that completed them, and the clan points they paid.',
+    },
+  ];
+};
+
+export async function loader() {
+  const [log, users, womMembers] = await Promise.all([
+    getSlayerLog(),
+    getUsersWithNicknames(),
+    getClanFromWom(),
+  ]);
+
+  // Slayer rows key off discordId; names and rank icons come from the roster, the same
+  // bridge every other page uses.
+  const roleByName = new Map(
+    womMembers.map(member => [
+      member.player.displayName.toLocaleLowerCase(),
+      member.role,
+    ]),
+  );
+  const members = Object.fromEntries(
+    users
+      .filter(user => user.nickname)
+      .map(user => [
+        user.discordId,
+        {
+          nickname: user.nickname ?? '',
+          role:
+            roleByName.get((user.nickname ?? '').toLocaleLowerCase()) ??
+            'Guest',
+        },
+      ]),
+  );
+
+  return json(
+    { ...log, members },
+    { headers: { 'Cache-Control': 'max-age=300' } },
+  );
+}
+
+export default function Slayer() {
+  const {
+    liveWheel,
+    rulesWheel,
+    completions,
+    activeTasks,
+    tasksAssigned,
+    tasksAbandoned,
+    members,
+  } = useLoaderData<typeof loader>();
+  const navigate = useNavigate();
+  const [sortField, setSortField] = useState<SortField>('tasks');
+  const [sortDirection, setSortDirection] = useState<SortDirection>('desc');
+
+  // One row per member who has ever been assigned a task that mattered: everyone with a
+  // completion, plus everyone out on task right now.
+  const slayers = [
+    ...completions
+      .reduce((rows, completion) => {
+        const row = rows.get(completion.discordId) ?? {
+          discordId: completion.discordId,
+          tasks: 0,
+          clanPoints: 0,
+          bonusPoints: 0,
+          loot: 0,
+        };
+        return rows.set(completion.discordId, {
+          ...row,
+          tasks: row.tasks + 1,
+          clanPoints: row.clanPoints + completion.clanPoints,
+          bonusPoints: row.bonusPoints + completion.bonusPoints,
+          loot: row.loot + completion.itemValue,
+        });
+      }, new Map<string, { discordId: string; tasks: number; clanPoints: number; bonusPoints: number; loot: number }>())
+      .values(),
+    ...activeTasks
+      .filter(task => !completions.some(c => c.discordId === task.discordId))
+      .map(task => ({
+        discordId: task.discordId,
+        tasks: 0,
+        clanPoints: 0,
+        bonusPoints: 0,
+        loot: 0,
+      })),
+  ].map(row => {
+    const member = members[row.discordId];
+    return {
+      ...row,
+      // Members who left keep their record; the roster just can't name them.
+      name: member?.nickname ?? 'Former member',
+      role: member?.role ?? 'Guest',
+      isMember: member !== undefined,
+      activeTask:
+        activeTasks.find(task => task.discordId === row.discordId) ?? null,
+    };
+  });
+
+  const totalTasks = completions.length;
+  const totalClanPoints = completions.reduce((sum, c) => sum + c.clanPoints, 0);
+  const totalBonusPoints = completions.reduce(
+    (sum, c) => sum + c.bonusPoints,
+    0,
+  );
+  const totalLoot = completions.reduce((sum, c) => sum + c.itemValue, 0);
+  // The bonus column only earns its width once a competition has actually paid one.
+  const hasBonus = totalBonusPoints > 0;
+
+  const navigateToUser = (discordId: string, isMember: boolean) => {
+    if (!isMember) return;
+    navigate(`/users/${discordId}`);
+  };
+
+  const sortedSlayers = [...slayers].sort((a, b) => {
+    const direction = sortDirection === 'asc' ? 1 : -1;
+    const tasksTiebreak = b.tasks - a.tasks;
+    switch (sortField) {
+      case 'name':
+        return direction * a.name.localeCompare(b.name) || tasksTiebreak;
+      case 'clanPoints':
+        return direction * (a.clanPoints - b.clanPoints) || tasksTiebreak;
+      case 'bonusPoints':
+        return direction * (a.bonusPoints - b.bonusPoints) || tasksTiebreak;
+      case 'loot':
+        return direction * (a.loot - b.loot) || tasksTiebreak;
+      case 'tasks':
+      default:
+        return direction * (a.tasks - b.tasks) || b.clanPoints - a.clanPoints;
+    }
+  });
+
+  const onSortColumn = (field: SortField) => {
+    if (field === sortField) {
+      setSortDirection(direction => (direction === 'asc' ? 'desc' : 'asc'));
+      return;
+    }
+    setSortField(field);
+    // Every column but the name leads with the biggest grinders.
+    setSortDirection(field === 'name' ? 'asc' : 'desc');
+  };
+
+  const completionsPagination = usePagination(completions, 10);
+
+  const leaderBoards: ILeaderBoard[] = [
+    {
+      key: 'tasks',
+      title: 'Most tasks completed',
+      valueClassName: 'text-white',
+      entries: [...slayers]
+        .sort((a, b) => b.tasks - a.tasks || b.loot - a.loot)
+        .slice(0, 3)
+        .map(row => ({
+          key: row.discordId,
+          iconSrc: fetchRankImage(row.role),
+          iconAlt: rankLabel(row.role),
+          label: row.name,
+          value: row.tasks.toLocaleString(),
+          onClick: row.isMember
+            ? () => navigateToUser(row.discordId, row.isMember)
+            : undefined,
+        })),
+    },
+    {
+      key: 'loot',
+      title: 'Most valuable task loot',
+      valueClassName: 'text-osrs-gold',
+      entries: [...slayers]
+        .sort((a, b) => b.loot - a.loot || b.tasks - a.tasks)
+        .slice(0, 3)
+        .map(row => ({
+          key: row.discordId,
+          iconSrc: fetchRankImage(row.role),
+          iconAlt: rankLabel(row.role),
+          label: row.name,
+          value: `${formatGp(row.loot)} gp`,
+          onClick: row.isMember
+            ? () => navigateToUser(row.discordId, row.isMember)
+            : undefined,
+        })),
+    },
+  ];
+
+  const sortColumns: {
+    field: SortField;
+    label: string;
+    align: 'left' | 'right';
+    className: string;
+  }[] = [
+    { field: 'name', label: 'Slayer', align: 'left', className: '' },
+    {
+      field: 'tasks',
+      label: 'Tasks',
+      align: 'right',
+      className: 'justify-end',
+    },
+    ...(hasBonus
+      ? [
+          {
+            field: 'bonusPoints' as const,
+            label: 'Bonus pts',
+            align: 'right' as const,
+            className: WIDE_COLUMN_CLASS,
+          },
+        ]
+      : []),
+    {
+      field: 'clanPoints',
+      label: 'Clan pts',
+      align: 'right',
+      className: 'justify-end',
+    },
+    {
+      field: 'loot',
+      label: 'Loot',
+      align: 'right',
+      className: WIDE_COLUMN_CLASS,
+    },
+  ];
+
+  // Three tiers, because the table shares its row with the completions feed at lg: phones get
+  // name/tasks/clan points, md widens to the full set, and lg drops back to the compact set
+  // until xl has room for everything again.
+  const rowGridClass = hasBonus
+    ? 'grid grid-cols-[24px_1fr_52px_64px] items-center gap-2 px-2 md:grid-cols-[40px_1fr_76px_88px_88px_104px] md:gap-3 md:px-3 lg:grid-cols-[28px_1fr_60px_76px] lg:gap-2 lg:px-2 xl:grid-cols-[28px_1fr_60px_76px_76px_84px]'
+    : 'grid grid-cols-[24px_1fr_52px_64px] items-center gap-2 px-2 md:grid-cols-[40px_1fr_88px_88px_112px] md:gap-3 md:px-3 lg:grid-cols-[28px_1fr_68px_80px] lg:gap-2 lg:px-2 xl:grid-cols-[28px_1fr_68px_80px_92px]';
+
+  const isCompetition = liveWheel?.mode === WHEEL_MODE.EVENT;
+
+  return (
+    <Container size="4" mt="3" pb="6">
+      <Flex direction="column">
+        <PageHeader title="Slayer" iconSrc={SLAYER_ICON}>
+          The Slayer Master assigns a random boss, and any point-worthy drop
+          from it completes the task.{' '}
+          {totalTasks > 0 ? (
+            <>
+              <span className="font-semibold text-sanguine-bright">
+                {slayers.filter(row => row.tasks > 0).length}
+              </span>{' '}
+              members have finished{' '}
+              <span className="font-semibold text-white">
+                {totalTasks.toLocaleString()}
+              </span>{' '}
+              {totalTasks === 1 ? 'task' : 'tasks'} between them
+              {totalClanPoints > 0 && (
+                <>
+                  {', worth '}
+                  <span className="font-semibold text-osrs-gold">
+                    {totalClanPoints.toLocaleString()}
+                  </span>{' '}
+                  clan points
+                </>
+              )}
+              {totalLoot > 0 && (
+                <>
+                  {' and '}
+                  <span className="font-semibold text-osrs-gold">
+                    {totalLoot.toLocaleString()} gp
+                  </span>{' '}
+                  of loot
+                </>
+              )}
+              .
+            </>
+          ) : (
+            <>Nobody has finished one yet.</>
+          )}
+          {activeTasks.length > 0 && (
+            <>
+              {' '}
+              <span className="font-semibold text-white">
+                {activeTasks.length}
+              </span>{' '}
+              {activeTasks.length === 1 ? 'member is' : 'members are'} out on
+              task right now.
+            </>
+          )}
+          {isCompetition && liveWheel && (
+            <>
+              {' '}
+              The <span className="text-sanguine-bright">
+                {liveWheel.name}
+              </span>{' '}
+              competition runs until {dayjs(liveWheel.endDate).format('MMMM D')}
+              , paying{' '}
+              <span className="text-white">{liveWheel.multiplier}x</span> drop
+              points on task drops.
+            </>
+          )}
+        </PageHeader>
+
+        {totalTasks === 0 && activeTasks.length === 0 ? (
+          <EmptyState>
+            {rulesWheel === null
+              ? 'The Slayer Master is out. Nothing interesting happens.'
+              : "'Ello, and what are you after then? Nobody is on task."}
+          </EmptyState>
+        ) : (
+          <>
+            {totalTasks > 0 && <LeaderBand boards={leaderBoards} />}
+
+            {/* The task log and the drops that finished the tasks share the row on large
+                screens, divided by one red rule; they stack on mobile. */}
+            <div className="grid grid-cols-1 gap-10 lg:grid-cols-2 lg:gap-0 lg:divide-x-2 lg:divide-sanguine-red">
+              {/* Task log: hiscores-style zebra rows, one per slayer */}
+              <section className="lg:pr-8">
+                <SectionHeading
+                  title="Task log"
+                  summary={
+                    <Text size="2" className="text-gray-500">
+                      <span className="text-white">{slayers.length}</span>{' '}
+                      slayers
+                    </Text>
+                  }
+                />
+                <Box mt="2">
+                  <div
+                    className={`${rowGridClass} border-b border-gray-700 py-2.5 text-osrs-orange`}
+                  >
+                    <span className="text-right text-sm">#</span>
+                    {sortColumns.map(column => (
+                      <SortableHeaderButton
+                        key={column.field}
+                        label={column.label}
+                        align={column.align}
+                        active={sortField === column.field}
+                        direction={sortDirection}
+                        onClick={() => onSortColumn(column.field)}
+                        className={column.className}
+                      />
+                    ))}
+                  </div>
+                  {sortedSlayers.map((row, index) => (
+                    <div
+                      key={row.discordId}
+                      onClick={() =>
+                        navigateToUser(row.discordId, row.isMember)
+                      }
+                      onKeyDown={e => {
+                        if (e.key === 'Enter') {
+                          navigateToUser(row.discordId, row.isMember);
+                        }
+                      }}
+                      role={row.isMember ? 'link' : undefined}
+                      tabIndex={row.isMember ? 0 : undefined}
+                      className={`${rowGridClass} group py-2 ${zebraRowClass} ${
+                        row.isMember ? 'cursor-pointer' : ''
+                      }`}
+                    >
+                      <Text
+                        as="div"
+                        size="2"
+                        className="text-right text-gray-600"
+                      >
+                        {index + 1}
+                      </Text>
+                      <Flex align="center" gap="3" className="min-w-0">
+                        <img
+                          src={fetchRankImage(row.role)}
+                          alt={rankLabel(row.role)}
+                          width={22}
+                          height={22}
+                          className="shrink-0 [image-rendering:pixelated]"
+                        />
+                        <Box className="min-w-0">
+                          <Text
+                            as="div"
+                            className={`truncate leading-tight ${
+                              row.isMember
+                                ? 'text-sanguine-bright group-hover:text-white'
+                                : 'text-gray-400'
+                            }`}
+                          >
+                            {row.name}
+                          </Text>
+                          {/* The current task replaces the rank sublabel — on this page
+                              what a member is hunting is the more useful fact. */}
+                          <Text
+                            as="div"
+                            size="1"
+                            className="truncate text-gray-500"
+                          >
+                            {row.activeTask
+                              ? `On task: ${row.activeTask.bossDisplayName}`
+                              : rankLabel(row.role)}
+                          </Text>
+                        </Box>
+                      </Flex>
+                      <Text
+                        as="div"
+                        className={`text-right ${
+                          row.tasks === 0 ? 'text-gray-600' : 'text-white'
+                        }`}
+                      >
+                        {row.tasks}
+                      </Text>
+                      {hasBonus && (
+                        <Text
+                          as="div"
+                          className={`text-right ${WIDE_CELL_CLASS} ${
+                            row.bonusPoints === 0
+                              ? 'text-gray-600'
+                              : 'text-white'
+                          }`}
+                        >
+                          {row.bonusPoints.toLocaleString()}
+                        </Text>
+                      )}
+                      <Text
+                        as="div"
+                        className={`text-right ${
+                          row.clanPoints === 0
+                            ? 'text-gray-600'
+                            : 'text-osrs-gold'
+                        }`}
+                      >
+                        {row.clanPoints.toLocaleString()}
+                      </Text>
+                      <Text
+                        as="div"
+                        size="2"
+                        className={`text-right tabular-nums ${WIDE_CELL_CLASS} ${
+                          row.loot === 0 ? 'text-gray-600' : 'text-osrs-gold'
+                        }`}
+                      >
+                        {row.loot === 0 ? 0 : formatGp(row.loot)}
+                      </Text>
+                    </div>
+                  ))}
+                </Box>
+              </section>
+
+              {/* Completions: the drop that finished each task, newest first */}
+              <section className="lg:pl-8">
+                <SectionHeading
+                  title="Completions"
+                  summary={
+                    <Text size="2" className="text-gray-500">
+                      <span className="text-white">{totalTasks}</span> tasks
+                      finished
+                    </Text>
+                  }
+                />
+                {completions.length > 0 ? (
+                  <Box mt="2">
+                    {completionsPagination.pageItems.map(completion => {
+                      const member = members[completion.discordId];
+                      return (
+                        <Flex
+                          key={completion.id}
+                          align="center"
+                          gap="3"
+                          className={`border-b border-gray-800 px-2 py-2 ${zebraStripeClass}`}
+                        >
+                          <Box className="flex h-7 w-7 shrink-0 items-center justify-center">
+                            {completion.itemIcon && (
+                              <img
+                                src={completion.itemIcon}
+                                alt=""
+                                className="max-h-7 max-w-7 object-contain"
+                              />
+                            )}
+                          </Box>
+                          <Box className="min-w-0 flex-1">
+                            <Text
+                              as="div"
+                              size="2"
+                              weight="medium"
+                              className="truncate text-white"
+                            >
+                              {completion.itemName}
+                            </Text>
+                            {/* Who finished it, and the task it finished */}
+                            <Text
+                              as="div"
+                              size="2"
+                              className="truncate text-gray-400"
+                            >
+                              {member ? (
+                                <Link
+                                  to={`/users/${completion.discordId}`}
+                                  className={proseLinkClass}
+                                >
+                                  {member.nickname}
+                                </Link>
+                              ) : (
+                                'Former member'
+                              )}
+                              {' · '}
+                              {completion.bossDisplayName}
+                            </Text>
+                          </Box>
+                          {/* Same right-hand stack as the drop log: date, value, points */}
+                          <Flex
+                            direction="column"
+                            align="end"
+                            className="shrink-0"
+                          >
+                            <Text
+                              as="div"
+                              size="2"
+                              className="whitespace-nowrap text-gray-400"
+                            >
+                              {dayjs(completion.completedAt).format(
+                                'MMM D, YYYY',
+                              )}
+                            </Text>
+                            {completion.itemValue > 0 && (
+                              <Text
+                                as="div"
+                                size="2"
+                                className="whitespace-nowrap text-osrs-gold"
+                              >
+                                <CoinsIcon />{' '}
+                                {completion.itemValue.toLocaleString()}
+                              </Text>
+                            )}
+                            {completion.clanPoints > 0 && (
+                              <Text
+                                as="div"
+                                size="2"
+                                weight="medium"
+                                className="whitespace-nowrap text-osrs-gold"
+                              >
+                                +{completion.clanPoints} clan
+                              </Text>
+                            )}
+                            {completion.bonusPoints > 0 && (
+                              <Text
+                                as="div"
+                                size="2"
+                                weight="medium"
+                                className="whitespace-nowrap text-white"
+                              >
+                                +{completion.bonusPoints} pts
+                              </Text>
+                            )}
+                          </Flex>
+                        </Flex>
+                      );
+                    })}
+                    <Pagination
+                      page={completionsPagination.page}
+                      totalPages={completionsPagination.totalPages}
+                      onPrev={completionsPagination.onPrev}
+                      onNext={completionsPagination.onNext}
+                    />
+                  </Box>
+                ) : (
+                  <EmptyState>
+                    No tasks finished yet. Nothing interesting happens.
+                  </EmptyState>
+                )}
+              </section>
+            </div>
+          </>
+        )}
+
+        {/* The rules, read off the running instance so the numbers can never go stale */}
+        {rulesWheel && (
+          <section className="mt-10">
+            <SectionHeading
+              title="How it works"
+              summary={
+                <Text size="2" className="text-gray-500">
+                  <span className="text-white">{rulesWheel.bossPoolSize}</span>{' '}
+                  bosses in the pool
+                </Text>
+              }
+            />
+            <Text as="p" size="3" className="mt-3 leading-7 text-gray-300">
+              Run <span className="text-white">/slayer task</span> in Discord
+              and the Slayer Master spins for one of{' '}
+              <span className="text-white">{rulesWheel.bossPoolSize}</span>{' '}
+              bosses. Any drop from that boss that is worth{' '}
+              <Link to="/drops" className={proseLinkClass}>
+                drop points
+              </Link>{' '}
+              completes the task. Your Dink webhook posts it like normal and the
+              bot does the rest, so there is nothing to submit.
+            </Text>
+            <Text as="p" size="3" className="mt-3 leading-7 text-gray-300">
+              {rulesWheel.taskClanPoints > 0 ? (
+                <>
+                  Every completed task pays{' '}
+                  <span className="text-osrs-gold">
+                    {rulesWheel.taskClanPoints} clan points
+                  </span>{' '}
+                  on top of whatever the drop was already worth.
+                </>
+              ) : (
+                <>
+                  During a competition, task drops pay{' '}
+                  <span className="text-white">
+                    {rulesWheel.multiplier}x drop points
+                  </span>{' '}
+                  and the podium takes{' '}
+                  <span className="text-osrs-gold">
+                    {rulesWheel.prizePoints.first} /{' '}
+                    {rulesWheel.prizePoints.second} /{' '}
+                    {rulesWheel.prizePoints.third} clan points
+                  </span>
+                  .
+                </>
+              )}{' '}
+              Hate the task? A free respin unlocks{' '}
+              <span className="text-white">
+                {rulesWheel.respinCooldownHours} hours
+              </span>{' '}
+              after it was handed out, or spend a skip to swap it instantly.
+              Everyone starts with{' '}
+              <span className="text-white">{rulesWheel.startingRerolls}</span>{' '}
+              skips and earns {rulesWheel.rerollEarnRate} back per completed
+              task.
+            </Text>
+            <Text as="p" size="3" className="mt-3 leading-7 text-gray-300">
+              Pets count. Raid tasks accept any mode, normal or hard. Drops from
+              a registered alt credit your main, same as regular points.
+              {tasksAssigned > 0 && (
+                <>
+                  {' '}
+                  So far the Slayer Master has handed out{' '}
+                  <span className="text-white">
+                    {tasksAssigned.toLocaleString()}
+                  </span>{' '}
+                  tasks, of which{' '}
+                  <span className="text-white">
+                    {tasksAbandoned.toLocaleString()}
+                  </span>{' '}
+                  were skipped or respun.
+                </>
+              )}
+            </Text>
+            <dl className="mt-4 border-t-2 border-t-sanguine-red">
+              {[
+                {
+                  command: '/slayer task',
+                  detail: 'get a task, or add skip:True to spend a skip',
+                },
+                {
+                  command: '/slayer status',
+                  detail: 'your task, your free respin timer, your skips',
+                },
+                { command: '/slayer log', detail: 'the current standings' },
+              ].map(({ command, detail }) => (
+                <div
+                  key={command}
+                  className={`grid grid-cols-[9.5rem_1fr] gap-x-3 border-b border-gray-800 px-2 py-2 ${zebraStripeClass}`}
+                >
+                  <dt className="whitespace-nowrap text-base text-white">
+                    {command}
+                  </dt>
+                  <dd className="text-base text-gray-400">{detail}</dd>
+                </div>
+              ))}
+            </dl>
+          </section>
+        )}
+      </Flex>
+    </Container>
+  );
+}

--- a/app/routes/users_.$id.tsx
+++ b/app/routes/users_.$id.tsx
@@ -74,6 +74,7 @@ import {
   isClanPointAudit,
   isLegacyCompetitionAudit,
 } from '~/utils/point-types';
+import { getSlayerRecordForDiscordId } from '~/services/slayer-service.server';
 
 export const meta: MetaFunction<typeof loader> = ({ data }) => {
   const title = data?.user?.nickname
@@ -100,6 +101,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     userAlts,
     pbCategoryKeys,
     raidCompletions,
+    slayerRecord,
     templeClog,
   ] = await Promise.all([
     getUserWithNickname(discordId),
@@ -108,6 +110,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     getUserAlts(discordId),
     getPersonalBestCategoryKeysForDiscordId(discordId),
     getRaidCompletionsForDiscordId(discordId),
+    getSlayerRecordForDiscordId(discordId),
     getGroupCollectionLog().catch(() => null),
   ]);
 
@@ -177,6 +180,17 @@ export async function loader({ params }: LoaderFunctionArgs) {
           to: historicalAwards[0].createdAt,
         }
       : null;
+  // Slayer's clan-bucket audits are the reconciling total: the flat per-task rewards the spin
+  // documents carry, plus anything else the wheel paid (competition podium prizes). The
+  // difference between the two is surfaced as one prize line rather than guessed at per row.
+  const slayerAuditPoints = userAuditData
+    .filter(x => x.type === 'BOSS_WHEEL_CLAN')
+    .reduce((sum, x) => sum + x.pointsGiven, 0);
+  const slayer = {
+    ...slayerRecord,
+    prizePoints: Math.max(0, slayerAuditPoints - slayerRecord.taskClanPoints),
+  };
+
   // Manual clan awards (event prizes, corrections) — surfaced as one lump sum, not a ledger.
   const otherClanAudits = userAuditData.filter(x => x.type === 'CLAN_MANUAL');
   const otherAwards =
@@ -299,6 +313,7 @@ export async function loader({ params }: LoaderFunctionArgs) {
     competitionAwards,
     historicalCompetitions,
     otherAwards,
+    slayer,
     pbNameByDiscordId,
     pbBossImageByName,
     clogSummaries,
@@ -330,6 +345,7 @@ export default function UserById() {
     competitionAwards,
     historicalCompetitions,
     otherAwards,
+    slayer,
     pbNameByDiscordId,
     pbBossImageByName,
     clogSummaries,
@@ -428,9 +444,10 @@ export default function UserById() {
     clogPagination.reset();
   };
 
-  // Raids paginate independently of drops — they ignore the account switcher, so their page
-  // never needs resetting.
+  // Raids and slayer tasks paginate independently of drops — they ignore the account
+  // switcher, so their pages never need resetting.
   const raidsPagination = usePagination(raids, itemsPerPage);
+  const slayerPagination = usePagination(slayer.completions, itemsPerPage);
 
   const totalGP = filteredItems.reduce(
     (sum, item) => sum + (item.osrsData?.price || 0),
@@ -457,13 +474,19 @@ export default function UserById() {
   const competitionsPointsTotal =
     competitionAwards.reduce((sum, a) => sum + a.pointsGiven, 0) +
     (historicalCompetitions?.points ?? 0);
+  const hasSlayerHistory = slayer.completions.length > 0;
+  const slayerPointsTotal = slayer.taskClanPoints + slayer.prizePoints;
   const hasClanPointHistory =
-    raids.length > 0 || hasCompetitionHistory || otherAwards !== null;
+    raids.length > 0 ||
+    hasCompetitionHistory ||
+    hasSlayerHistory ||
+    otherAwards !== null;
   // Subsection headers exist to divide multiple point sources (their totals reconcile
   // the section figure). With a single source they'd just repeat the h2 total — skip them.
   const clanPointSources = [
     raids.length > 0,
     hasCompetitionHistory,
+    hasSlayerHistory,
     otherAwards !== null,
   ].filter(Boolean).length;
 
@@ -504,6 +527,9 @@ export default function UserById() {
                       : []),
                     ...(hasCompetitionHistory
                       ? [{ id: 'competitions', title: 'Competitions' }]
+                      : []),
+                    ...(hasSlayerHistory
+                      ? [{ id: 'slayer', title: 'Slayer' }]
                       : []),
                     ...(otherAwards
                       ? [{ id: 'other-awards', title: 'Other' }]
@@ -594,6 +620,7 @@ export default function UserById() {
   const categories = [
     ...(isGuest ? [] : [mainRankLabel]),
     ...(raids.length > 0 ? ['Raiders'] : []),
+    ...(hasSlayerHistory ? ['Slayers'] : []),
     ...(pbGolds > 0 ? ['Clan record holders'] : []),
     ...(compPodiums > 0 ? ['Competition medalists'] : []),
   ];
@@ -739,6 +766,20 @@ export default function UserById() {
             {raids.length > 0 && (
               <InfoboxRow label="Raids">{raids.length}</InfoboxRow>
             )}
+            {(hasSlayerHistory || slayer.activeTask) && (
+              <InfoboxRow label="Slayer">
+                {hasSlayerHistory
+                  ? `${slayer.completions.length} ${
+                      slayer.completions.length === 1 ? 'task' : 'tasks'
+                    }`
+                  : 'out on task'}
+                {slayer.activeTask && (
+                  <span className="block text-sm text-gray-500">
+                    on task: {slayer.activeTask.bossDisplayName}
+                  </span>
+                )}
+              </InfoboxRow>
+            )}
             {totalComps > 0 && (
               <InfoboxRow label="Competitions">
                 {totalComps}
@@ -875,6 +916,27 @@ export default function UserById() {
                     ,{' '}
                     <span className="text-osrs-gold">
                       {pbGolds} of them clan records
+                    </span>
+                  </>
+                )}
+                .
+              </>
+            )}
+            {hasSlayerHistory && (
+              <>
+                {' '}
+                For the{' '}
+                <Link to="/slayer" className={proseLinkClass}>
+                  Slayer Master
+                </Link>{' '}
+                they have completed{' '}
+                <span className="text-white">{slayer.completions.length}</span>{' '}
+                {slayer.completions.length === 1 ? 'task' : 'tasks'}
+                {slayerPointsTotal > 0 && (
+                  <>
+                    , worth{' '}
+                    <span className="text-osrs-gold">
+                      {slayerPointsTotal.toLocaleString()} clan points
                     </span>
                   </>
                 )}
@@ -1399,6 +1461,181 @@ export default function UserById() {
                         </Table.Body>
                       </Table.Root>
                     </div>
+                  </Box>
+                )}
+
+                {/* Slayer — the tasks the Slayer Master set and the drop that finished
+                    each one. Keyed to the member, so it ignores the account switcher; the
+                    completing account is noted on the row instead. */}
+                {hasSlayerHistory && (
+                  <Box id="slayer" className="scroll-mt-20">
+                    {clanPointSources > 1 && (
+                      <SubsectionHeading
+                        title="Slayer"
+                        hint="boss tasks completed"
+                        summary={
+                          <Text
+                            size="2"
+                            className="whitespace-nowrap text-gray-500"
+                          >
+                            <span className="text-osrs-gold">
+                              {slayerPointsTotal}
+                            </span>{' '}
+                            clan points
+                          </Text>
+                        }
+                      />
+                    )}
+                    {slayer.activeTask && (
+                      <Text as="p" size="2" className="pb-1 text-gray-500">
+                        Currently on task:{' '}
+                        <span className="text-white">
+                          {slayer.activeTask.bossDisplayName}
+                        </span>
+                        , assigned{' '}
+                        {dayjs(slayer.activeTask.spunAt).format('MMM D')}
+                      </Text>
+                    )}
+                    <div className="overflow-x-auto">
+                      <Table.Root size="2">
+                        <Table.Header>
+                          <Table.Row>
+                            <Table.ColumnHeaderCell className="text-osrs-orange">
+                              Task
+                            </Table.ColumnHeaderCell>
+                            <Table.ColumnHeaderCell className="hidden text-osrs-orange sm:table-cell">
+                              Completed by
+                            </Table.ColumnHeaderCell>
+                            <Table.ColumnHeaderCell className="hidden text-osrs-orange sm:table-cell">
+                              Date
+                            </Table.ColumnHeaderCell>
+                            <Table.ColumnHeaderCell
+                              className="whitespace-nowrap text-osrs-orange"
+                              align="right"
+                            >
+                              Clan pts
+                            </Table.ColumnHeaderCell>
+                          </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                          {slayerPagination.pageItems.map(completion => (
+                            <Table.Row
+                              key={completion.id}
+                              className={zebraRowClass}
+                            >
+                              <Table.Cell className="text-white">
+                                <Flex align="center" gap="2">
+                                  <Box className="flex h-7 w-7 flex-shrink-0 items-center justify-center">
+                                    <img
+                                      src={completion.bossImageUrl}
+                                      alt=""
+                                      className="max-h-7 max-w-7 object-contain"
+                                    />
+                                  </Box>
+                                  <Flex direction="column">
+                                    <Text size="2" weight="medium">
+                                      {completion.bossDisplayName}
+                                    </Text>
+                                    {/* Phones lose the item column — two icon
+                                        columns squeeze the names to a word per
+                                        line — so the drop reads underneath. */}
+                                    <Text
+                                      size="2"
+                                      className="text-gray-300 sm:hidden"
+                                    >
+                                      {completion.itemName}
+                                    </Text>
+                                  </Flex>
+                                </Flex>
+                              </Table.Cell>
+                              <Table.Cell className="hidden sm:table-cell">
+                                <Flex align="center" gap="2">
+                                  <Box className="flex h-6 w-6 flex-shrink-0 items-center justify-center">
+                                    {completion.itemIcon && (
+                                      <img
+                                        src={completion.itemIcon}
+                                        alt=""
+                                        className="max-h-6 max-w-6 object-contain"
+                                      />
+                                    )}
+                                  </Box>
+                                  <Flex direction="column">
+                                    <Text size="2" className="text-white">
+                                      {completion.itemName}
+                                    </Text>
+                                    {completion.osrsName && (
+                                      <Text size="1" className="text-gray-500">
+                                        on {completion.osrsName}
+                                      </Text>
+                                    )}
+                                  </Flex>
+                                </Flex>
+                              </Table.Cell>
+                              <Table.Cell className="hidden text-gray-400 sm:table-cell">
+                                <span className="whitespace-nowrap">
+                                  {dayjs(completion.completedAt).format(
+                                    'MMM D,',
+                                  )}
+                                </span>{' '}
+                                <span className="whitespace-nowrap">
+                                  {dayjs(completion.completedAt).format('YYYY')}
+                                </span>
+                              </Table.Cell>
+                              <Table.Cell align="right">
+                                <Text
+                                  as="div"
+                                  size="2"
+                                  className={`whitespace-nowrap font-medium ${
+                                    completion.clanPoints === 0
+                                      ? 'text-gray-600'
+                                      : 'text-osrs-gold'
+                                  }`}
+                                >
+                                  {completion.clanPoints === 0
+                                    ? '—'
+                                    : `+${completion.clanPoints}`}
+                                </Text>
+                                {/* Competition tasks pay bonus drop points instead —
+                                    white, never gold (see the color grammar). */}
+                                {completion.bonusPoints > 0 && (
+                                  <Text
+                                    as="div"
+                                    size="1"
+                                    className="whitespace-nowrap text-white"
+                                  >
+                                    +{completion.bonusPoints} pts
+                                  </Text>
+                                )}
+                              </Table.Cell>
+                            </Table.Row>
+                          ))}
+                          {/* Competition podium and participation prizes, rolled up */}
+                          {slayer.prizePoints > 0 && (
+                            <Table.Row className={zebraStripeClass}>
+                              <Table.Cell>
+                                <Text size="2" className="text-gray-400">
+                                  Competition prizes
+                                </Text>
+                              </Table.Cell>
+                              <Table.Cell className="hidden sm:table-cell" />
+                              <Table.Cell className="hidden sm:table-cell" />
+                              <Table.Cell
+                                align="right"
+                                className="whitespace-nowrap font-medium text-osrs-gold"
+                              >
+                                +{slayer.prizePoints}
+                              </Table.Cell>
+                            </Table.Row>
+                          )}
+                        </Table.Body>
+                      </Table.Root>
+                    </div>
+                    <Pagination
+                      page={slayerPagination.page}
+                      totalPages={slayerPagination.totalPages}
+                      onPrev={slayerPagination.onPrev}
+                      onNext={slayerPagination.onNext}
+                    />
                   </Box>
                 )}
 

--- a/app/services/slayer-service.server.ts
+++ b/app/services/slayer-service.server.ts
@@ -1,0 +1,259 @@
+import {
+  getActiveSpins,
+  getCompletedSpins,
+  getSpinCountsByStatus,
+  getSpinsForDiscordId,
+  getWheelClanEvents,
+  getWheelConfigs,
+  SPIN_STATUS,
+} from '~/data/slayer';
+import { fetchOSRSItem } from '~/services/osrs-wiki-prices-service';
+import { getSlayerBossImageUrl, WHEEL_MODE } from '~/utils/slayer';
+
+// Sanguine Slayer: the Slayer Master assigns a random boss task, and a point-worthy drop from
+// that boss completes it. The Discord bot models it as the Boss Wheel — one WheelEvents config
+// per instance, one spin document per assigned task. This service turns those rows into the
+// shapes the site renders: the task log, the tasks members are out on, and one member's record.
+
+/** One instance of the feature: the always-on grind, or a time-boxed competition. */
+export interface ISlayerWheel {
+  clanEventId: string;
+  mode: string;
+  name: string;
+  /** Event-mode bonus multiplier on drop points (1 during the standing grind). */
+  multiplier: number;
+  /** Flat clan points paid per completed task (0 during competitions). */
+  taskClanPoints: number;
+  startingRerolls: number;
+  rerollEarnRate: number;
+  respinCooldownHours: number;
+  /** Podium and participation prizes, all zero during the standing grind. */
+  prizePoints: { first: number; second: number; third: number };
+  bossPoolSize: number;
+  startDate: string;
+  endDate: string;
+  isActive: boolean;
+}
+
+/** A completed task, with the drop that finished it. */
+export interface ISlayerCompletion {
+  id: string;
+  discordId: string;
+  bossDisplayName: string;
+  bossImageUrl: string;
+  itemId: number;
+  itemName: string;
+  itemIcon: string | null;
+  /** GE value of the completing item, 0 for untradeables (pets, jars). */
+  itemValue: number;
+  /** What the drop was worth normally — already counted in the member's drop points. */
+  dropPoints: number;
+  /** Event-mode bonus drop points paid on top (0 during the standing grind). */
+  bonusPoints: number;
+  /** Flat clan points the completion paid. */
+  clanPoints: number;
+  completedAt: string;
+  /** The account the drop came from, when it wasn't the main. */
+  osrsName: string | null;
+}
+
+/** A task a member is out on right now. */
+export interface ISlayerTask {
+  id: string;
+  discordId: string;
+  bossDisplayName: string;
+  bossImageUrl: string;
+  spunAt: string;
+}
+
+// Row shapes come from the data layer so the mock and the real client can't drift apart.
+type WheelConfigRow = Awaited<ReturnType<typeof getWheelConfigs>>[number];
+type ClanEventRow = Awaited<ReturnType<typeof getWheelClanEvents>>[number];
+type SpinRow = Awaited<ReturnType<typeof getCompletedSpins>>[number];
+
+/** Pairs each wheel config with the ClanEvents row that owns its window. */
+const buildWheels = (
+  configs: WheelConfigRow[],
+  clanEvents: ClanEventRow[],
+  nowIso: string,
+): ISlayerWheel[] => {
+  const windowByEventId = new Map(clanEvents.map(event => [event.id, event]));
+  return configs
+    .flatMap(config => {
+      const window = windowByEventId.get(config.clanEventId);
+      if (!window) return [];
+      return [
+        {
+          clanEventId: config.clanEventId,
+          mode: config.mode,
+          name: config.name,
+          multiplier: config.multiplier,
+          taskClanPoints: config.taskClanPoints,
+          startingRerolls: config.startingRerolls,
+          rerollEarnRate: config.rerollEarnRate,
+          respinCooldownHours: config.respinCooldownHours,
+          prizePoints: {
+            first: config.prizePoints.first,
+            second: config.prizePoints.second,
+            third: config.prizePoints.third,
+          },
+          bossPoolSize: config.bossPool.length,
+          startDate: window.startDate,
+          endDate: window.endDate,
+          isActive: window.startDate <= nowIso && window.endDate >= nowIso,
+        },
+      ];
+    })
+    .sort((a, b) => b.startDate.localeCompare(a.startDate));
+};
+
+/**
+ * The instance in effect right now. A running competition supersedes the standing grind, the
+ * same precedence the bot applies when a drop comes in.
+ */
+export const findLiveWheel = (wheels: ISlayerWheel[]): ISlayerWheel | null => {
+  const active = wheels.filter(wheel => wheel.isActive);
+  return (
+    active.find(wheel => wheel.mode === WHEEL_MODE.EVENT) ?? active[0] ?? null
+  );
+};
+
+/**
+ * Resolves the completing item against the wiki (icon and GE value). The stored item name is
+ * the verbatim Dink string; the wiki's is the one the rest of the site shows.
+ */
+const toCompletion = async (
+  spin: SpinRow,
+): Promise<ISlayerCompletion | null> => {
+  const { completion } = spin;
+  if (!completion) return null;
+  const osrsData = await fetchOSRSItem(completion.itemId);
+  return {
+    id: spin.id,
+    discordId: spin.discordId,
+    bossDisplayName: spin.task.bossDisplayName,
+    bossImageUrl: getSlayerBossImageUrl(
+      spin.task.bossMetric,
+      spin.task.bossDisplayName,
+    ),
+    itemId: completion.itemId,
+    itemName: osrsData?.name ?? completion.itemName,
+    itemIcon: osrsData?.icon ?? null,
+    itemValue: osrsData?.price ?? 0,
+    dropPoints: completion.dropPoints,
+    bonusPoints: completion.bonusPoints,
+    clanPoints: completion.taskClanPoints,
+    completedAt: completion.completedAt,
+    osrsName: completion.osrsName,
+  };
+};
+
+const toCompletions = async (
+  spins: SpinRow[],
+): Promise<ISlayerCompletion[]> => {
+  const completions = await Promise.all(spins.map(toCompletion));
+  return completions
+    .filter(
+      (completion): completion is ISlayerCompletion => completion !== null,
+    )
+    .sort((a, b) => b.completedAt.localeCompare(a.completedAt));
+};
+
+const toTask = (spin: SpinRow): ISlayerTask => ({
+  id: spin.id,
+  discordId: spin.discordId,
+  bossDisplayName: spin.task.bossDisplayName,
+  bossImageUrl: getSlayerBossImageUrl(
+    spin.task.bossMetric,
+    spin.task.bossDisplayName,
+  ),
+  spunAt: spin.spunAt,
+});
+
+export interface ISlayerLog {
+  /** Null when nothing is running right now. */
+  liveWheel: ISlayerWheel | null;
+  /** The live instance, or the most recent one — whatever the rules should be read from. */
+  rulesWheel: ISlayerWheel | null;
+  /** Every completed task, newest first, across every instance. */
+  completions: ISlayerCompletion[];
+  /** Tasks out on the live instance only — older instances' tasks are dead. */
+  activeTasks: ISlayerTask[];
+  /** Tasks handed out in total, and how many were traded away for another. */
+  tasksAssigned: number;
+  tasksAbandoned: number;
+}
+
+/** Everything the Slayer page renders, member identity aside. */
+export const getSlayerLog = async (
+  nowIso: string = new Date().toISOString(),
+): Promise<ISlayerLog> => {
+  const [configs, clanEvents, completedSpins, activeSpins, spinCounts] =
+    await Promise.all([
+      getWheelConfigs(),
+      getWheelClanEvents(),
+      getCompletedSpins(),
+      getActiveSpins(),
+      getSpinCountsByStatus(),
+    ]);
+
+  const wheels = buildWheels(configs, clanEvents, nowIso);
+  const liveWheel = findLiveWheel(wheels);
+  const completions = await toCompletions(completedSpins);
+  const activeTasks = activeSpins
+    .filter(spin => spin.clanEventId === liveWheel?.clanEventId)
+    .map(toTask)
+    .sort((a, b) => b.spunAt.localeCompare(a.spunAt));
+
+  return {
+    liveWheel,
+    // buildWheels sorts newest first, so the head is the most recent instance.
+    rulesWheel: liveWheel ?? wheels[0] ?? null,
+    completions,
+    activeTasks,
+    tasksAssigned: Object.values(spinCounts).reduce(
+      (sum, count) => sum + count,
+      0,
+    ),
+    tasksAbandoned: spinCounts[SPIN_STATUS.REPLACED] ?? 0,
+  };
+};
+
+export interface ISlayerRecord {
+  completions: ISlayerCompletion[];
+  /** The member's task right now, if the live instance has one for them. */
+  activeTask: ISlayerTask | null;
+  /** Clan points their completed tasks paid, prizes aside. */
+  taskClanPoints: number;
+  /** Event-mode bonus drop points their tasks paid. */
+  bonusDropPoints: number;
+}
+
+/** One member's slayer record, for their profile article. */
+export const getSlayerRecordForDiscordId = async (
+  discordId: string,
+  nowIso: string = new Date().toISOString(),
+): Promise<ISlayerRecord> => {
+  const [spins, configs, clanEvents] = await Promise.all([
+    getSpinsForDiscordId(discordId),
+    getWheelConfigs(),
+    getWheelClanEvents(),
+  ]);
+  const liveWheel = findLiveWheel(buildWheels(configs, clanEvents, nowIso));
+
+  const completions = await toCompletions(
+    spins.filter(spin => spin.status === SPIN_STATUS.COMPLETED),
+  );
+  const activeSpin = spins.find(
+    spin =>
+      spin.status === SPIN_STATUS.ACTIVE &&
+      spin.clanEventId === liveWheel?.clanEventId,
+  );
+
+  return {
+    completions,
+    activeTask: activeSpin ? toTask(activeSpin) : null,
+    taskClanPoints: completions.reduce((sum, c) => sum + c.clanPoints, 0),
+    bonusDropPoints: completions.reduce((sum, c) => sum + c.bonusPoints, 0),
+  };
+};

--- a/app/utils/point-types.ts
+++ b/app/utils/point-types.ts
@@ -1,7 +1,13 @@
-// PointAudit types that always pay into the clan-points bucket (GROUP_RAID payouts and manual
-// CLAN adjustments) rather than the drop-driven `points` bucket. Mirrors the Discord bot's
-// leaderboard exclusion — clan points never count toward drop-point charts or event totals.
-export const CLAN_POINT_AUDIT_TYPES = ['GROUP_RAID', 'CLAN_MANUAL'] as const;
+// PointAudit types that always pay into the clan-points bucket (GROUP_RAID payouts, manual
+// CLAN adjustments and Sanguine Slayer task rewards) rather than the drop-driven `points`
+// bucket. Mirrors the Discord bot's leaderboard exclusion — clan points never count toward
+// drop-point charts or event totals. Slayer's other audit type, BOSS_WHEEL, is a genuine
+// drop-point bonus and stays out of this list.
+export const CLAN_POINT_AUDIT_TYPES = [
+  'GROUP_RAID',
+  'CLAN_MANUAL',
+  'BOSS_WHEEL_CLAN',
+] as const;
 
 // When COMPETITION rewards (BOTW/SOTW/ROTW) moved from the drop-points bucket to clan points.
 // COMPETITION audits before this instant were drop points and still count toward drop-point

--- a/app/utils/slayer.ts
+++ b/app/utils/slayer.ts
@@ -1,0 +1,62 @@
+import {
+  getBossImageUrl,
+  getCompetitionImageUrl,
+  hasCompetitionImage,
+} from '~/utils/competition-images';
+
+/** The Slayer skill icon — the page's game asset, same source as competition thumbnails. */
+export const SLAYER_ICON =
+  'https://oldschool.runescape.wiki/images/Slayer_icon.png';
+
+/** Wheel modes, mirroring the bot's WheelMode enum. */
+export const WHEEL_MODE = {
+  /** The always-on grind: flat clan points per completed task, no end date. */
+  STANDING: 'STANDING',
+  /** A time-boxed competition: bonus drop points, a leaderboard, prizes. */
+  EVENT: 'EVENT',
+} as const;
+
+/**
+ * Wheel-pool metrics whose image the shared resolvers get wrong or miss: the pool is keyed by
+ * current WOM metric slugs (`kreearra`, `vetion`), while the competition map predates some of
+ * them, and WOM display names don't always match the wiki's file capitalization (`Kree'Arra`
+ * vs the wiki's `Kree'arra.png`). Verified against the live wiki, one entry per broken URL.
+ */
+const BOSS_IMAGE_BY_METRIC: Record<string, string> = {
+  // Chests and multi-boss encounters have no image of their own.
+  barrows_chests: 'Ahrim_the_Blighted.png',
+  lunar_chests: 'Eclipse_Moon.png',
+  the_royal_titans: 'Branda_the_Fire_Queen.png',
+  // Capitalization the wiki's file names don't share.
+  kreearra: "Kree'arra.png",
+  shellbane_gryphon: 'Shellbane_gryphon.png',
+};
+
+/**
+ * Loot totals the way the game writes them (1.2m, 340k), for the dense columns where a full
+ * gp figure would wrap. Prose and infobox rows still spell the number out.
+ */
+export const formatGp = (gp: number): string => {
+  if (gp >= 1_000_000_000) return `${(gp / 1_000_000_000).toFixed(1)}b`;
+  if (gp >= 1_000_000) return `${(gp / 1_000_000).toFixed(1)}m`;
+  if (gp >= 10_000) return `${Math.round(gp / 1_000)}k`;
+  return gp.toLocaleString();
+};
+
+/**
+ * Thumbnail for an assigned boss. Tasks store both the WOM metric and the display name they
+ * were spun with, so this prefers the curated per-metric asset, then the competition image,
+ * then the drop-log resolver's guess from the display name.
+ */
+export const getSlayerBossImageUrl = (
+  bossMetric: string,
+  bossDisplayName: string,
+): string => {
+  const override = BOSS_IMAGE_BY_METRIC[bossMetric];
+  if (override) {
+    return `https://oldschool.runescape.wiki/images/${override}`;
+  }
+  return hasCompetitionImage(bossMetric)
+    ? getCompetitionImageUrl(bossMetric)
+    : getBossImageUrl(bossDisplayName);
+};

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -101,6 +101,82 @@ model RaidCompletions {
   approvedAt            String
 }
 
+// ---- Sanguine Slayer (the Discord bot calls it the Boss Wheel) ----
+
+// The item filter a task applies to qualifying drops (ANY / INCLUDE / EXCLUDE).
+type WheelTaskItemFilter {
+  mode    String
+  itemIds Int[]
+}
+
+// Snapshot of the assigned task, embedded on each spin so later alias/filter edits never
+// rewrite history. bossMetric is a WOM metric slug (e.g. 'general_graardor').
+type WheelTask {
+  type            String
+  bossMetric      String
+  bossDisplayName String
+  dinkNames       String[]
+  itemFilter      WheelTaskItemFilter
+}
+
+// The drop that finished a task. Strictly 1:1 with its spin, so the bot embeds it rather than
+// keeping a second collection. dropPoints/bonusPoints pay the drop bucket, taskClanPoints the
+// clan bucket (audited as BOSS_WHEEL / BOSS_WHEEL_CLAN).
+type WheelSpinCompletion {
+  itemId         Int
+  itemName       String
+  dropPoints     Int
+  bonusPoints    Int
+  eventPoints    Int
+  taskClanPoints Int
+  bossNameRaw    String
+  osrsName       String?
+  dropMessageId  String
+  completedAt    String
+}
+
+// One document per spin — the task log's full history. ACTIVE spins are the tasks members are
+// out on right now; COMPLETED ones carry their completion.
+model WheelSpins {
+  id           String               @id @default(auto()) @map("_id") @db.ObjectId
+  v            Int?                 @map("__v")
+  clanEventId  String               @db.ObjectId
+  discordId    String
+  task         WheelTask
+  spinType     String
+  status       String
+  spunAt       String
+  completion   WheelSpinCompletion?
+}
+
+// Podium/participation prizes paid when an EVENT-mode wheel ends (all zero in STANDING mode).
+type WheelPrizePoints {
+  first       Int
+  second      Int
+  third       Int
+  participant Int
+}
+
+// Per-instance wheel config, sibling to a BOSS_WHEEL ClanEvents row (which owns the window).
+// STANDING is the always-on grind; EVENT is a time-boxed competition that supersedes it.
+// taskOverrides is a Mongo map the site never reads, so it stays out of the model.
+model WheelEvents {
+  id                  String           @id @default(auto()) @map("_id") @db.ObjectId
+  v                   Int?             @map("__v")
+  clanEventId         String           @unique @db.ObjectId
+  mode                String
+  name                String
+  multiplier          Float
+  taskClanPoints      Int
+  startingRerolls     Int
+  rerollEarnRate      Float
+  respinCooldownHours Float
+  prizePoints         WheelPrizePoints
+  bossPool            String[]
+  createdByDiscordId  String
+  createdAt           String
+}
+
 model PersonalBests {
   id                    String   @id @default(auto()) @map("_id") @db.ObjectId
   v                     Int?     @map("__v")

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -30,6 +30,7 @@ const mockAliases = mockMode
       mockAlias('~/data/user', './app/mocks/user/index.ts'),
       mockAlias('~/data/nicknames', './app/mocks/nicknames/index.ts'),
       mockAlias('~/data/points-audit', './app/mocks/points-audit/index.ts'),
+      mockAlias('~/data/slayer', './app/mocks/slayer/index.ts'),
       mockAlias(
         '~/data/monthly-winners',
         './app/mocks/monthly-winners/index.ts',


### PR DESCRIPTION
Surfaces Sanguine Slayer on the site: a `/slayer` page and a matching section on member profiles.

The Discord bot models the feature as the Boss Wheel (one `WheelEvents` config per instance, one spin document per assigned task), so this adds Prisma models for `WheelSpins`/`WheelEvents` and a service that turns them into the shapes the site renders.

## /slayer

Built on the hiscores anatomy, since the grind is a standing ladder:

- Header prose narrating the totals, plus the running competition's multiplier and end date when one is live
- Leader band: most tasks completed (white counts) and most valuable task loot (gold gp)
- **Task log** — sortable zebra rows with the member's *current task* as the sublabel in place of the rank label, then Tasks / Bonus pts / Clan pts / Loot. The bonus column only exists once a competition has actually paid one; loot abbreviates game style (`1.3b`, `886.9m`)
- **Completions** — the drop that finished each task: item, member, boss, date, gp, and the points it paid
- **How it works** — rules read off the running instance (boss pool size, per-task clan points, respin cooldown, skips) so tuning the bot never makes the page lie, plus the three `/slayer` commands

## Member profiles

Slayer is a subsection of Clan points, so that section's totals still reconcile against the clan bucket. Task -> Completed by -> Date -> Clan pts, with a white `+N pts` annotation for competition bonuses and a rolled-up "Competition prizes" line when the audits exceed per-task rewards. Also an infobox row (`Slayer - 7 tasks / on task: Phosani's Nightmare`), a lede clause, a Contents entry, and a "Slayers" category.

## Bug fix

`BOSS_WHEEL_CLAN` was missing from `CLAN_POINT_AUDIT_TYPES`, so slayer clan points would have been counted as drop points in every member's chart and history. `BOSS_WHEEL` stays out of that list: it is a genuine drop point bonus.

## Notes

- Nav places Slayer top level rather than under Events, since the grind is always on rather than time boxed. Seven items overflowed the row at 768px, so the nav gap tightens at `md` and is restored at `lg`
- All 53 pool bosses' wiki thumbnails were checked against the live wiki; five needed overrides (Barrows, Lunar Chests, Royal Titans, Kree'arra, Shellbane gryphon)
- Mock fixtures cover both a standing instance and a finished competition, so `npm run dev:mock` exercises the clan point and bonus point paths
- The skeleton commit also carries the pre-existing uncommitted `SkeletonPageHeader` refactor and the Home/About skeletons

## Testing

- `npm run lint`, `npm run typecheck`, `npm test` (33 passing), prettier clean
- Rendered against mock data and the production database at 1440px, 1100px, and a real 390px viewport (CDP emulation, no horizontal overflow)
- Production currently has zero completions and 17 members out on task, so the empty states were verified against real data too
