### PR TITLE
Tile race: public race page and staff admin portal

### DIFF
--- a/app/components/MemberPicker.tsx
+++ b/app/components/MemberPicker.tsx
@@ -1,0 +1,185 @@
+import { useMemo, useState } from 'react';
+import { Text } from '@radix-ui/themes';
+import { Input } from '~/components/input';
+
+export interface IPickerMember {
+  discordId: string;
+  nickname: string;
+}
+
+interface IMemberPickerProps {
+  /** The clan roster to search — discordId + display nickname. */
+  members: IPickerMember[];
+  /** Name of the hidden input carrying the selected ids as a JSON array. */
+  inputName: string;
+  defaultSelectedIds?: string[];
+  id?: string;
+  placeholder?: string;
+}
+
+const MAX_SUGGESTIONS = 8;
+const RAW_DISCORD_ID = /^\d{5,25}$/;
+
+/**
+ * Typeahead multi-select over the clan roster: type a nickname, pick from the
+ * dropdown, selections collect as removable chips. Pasting a raw Discord id is
+ * the escape hatch for people missing from the roster. Submits ids via a hidden
+ * input so plain Remix form posts work.
+ */
+export function MemberPicker({
+  members,
+  inputName,
+  defaultSelectedIds = [],
+  id,
+  placeholder = 'Type a nickname…',
+}: IMemberPickerProps) {
+  const [selected, setSelected] = useState<string[]>(defaultSelectedIds);
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const nicknameById = useMemo(
+    () => new Map(members.map(m => [m.discordId, m.nickname])),
+    [members],
+  );
+
+  const trimmed = query.trim();
+  const suggestions = useMemo(() => {
+    if (!trimmed) {
+      return [];
+    }
+    const lower = trimmed.toLocaleLowerCase();
+    const matches = members
+      .filter(
+        m =>
+          !selected.includes(m.discordId) &&
+          m.nickname.toLocaleLowerCase().includes(lower),
+      )
+      .slice(0, MAX_SUGGESTIONS);
+    // Raw-id escape hatch for members not in the site roster
+    if (
+      !matches.length &&
+      RAW_DISCORD_ID.test(trimmed) &&
+      !selected.includes(trimmed)
+    ) {
+      return [{ discordId: trimmed, nickname: `Discord id ${trimmed}` }];
+    }
+    return matches;
+  }, [members, selected, trimmed]);
+
+  const pick = (discordId: string) => {
+    setSelected(current =>
+      current.includes(discordId) ? current : [...current, discordId],
+    );
+    setQuery('');
+    setActiveIndex(0);
+  };
+
+  const remove = (discordId: string) =>
+    setSelected(current => current.filter(id => id !== discordId));
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex(i => Math.min(i + 1, suggestions.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex(i => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter' && suggestions.length) {
+      // Swallow the submit only while choosing a suggestion
+      e.preventDefault();
+      pick(
+        suggestions[Math.min(activeIndex, suggestions.length - 1)].discordId,
+      );
+    } else if (e.key === 'Escape' && trimmed) {
+      e.preventDefault();
+      setQuery('');
+    } else if (e.key === 'Backspace' && !query && selected.length) {
+      remove(selected[selected.length - 1]);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <input type="hidden" name={inputName} value={JSON.stringify(selected)} />
+      {selected.length > 0 && (
+        <div className="flex flex-wrap gap-1.5">
+          {selected.map(discordId => {
+            const nickname = nicknameById.get(discordId);
+            return (
+              <span
+                key={discordId}
+                className="flex items-center gap-1.5 rounded-sm border border-gray-700 bg-gray-900 py-0.5 pl-2 pr-1"
+              >
+                <Text
+                  size="3"
+                  className={
+                    nickname ? 'text-sanguine-bright' : 'text-gray-400'
+                  }
+                >
+                  {nickname ?? discordId}
+                </Text>
+                <button
+                  type="button"
+                  onClick={() => remove(discordId)}
+                  aria-label={`Remove ${nickname ?? discordId}`}
+                  className="cursor-pointer px-1 text-gray-500 hover:text-white"
+                >
+                  ×
+                </button>
+              </span>
+            );
+          })}
+        </div>
+      )}
+      <div className="relative">
+        <Input
+          id={id}
+          value={query}
+          onChange={e => {
+            setQuery(e.target.value);
+            setActiveIndex(0);
+          }}
+          onKeyDown={onKeyDown}
+          onBlur={() => setQuery('')}
+          placeholder={placeholder}
+          className="text-base"
+          autoComplete="off"
+          role="combobox"
+          aria-expanded={suggestions.length > 0}
+          aria-autocomplete="list"
+        />
+        {suggestions.length > 0 && (
+          <ul
+            role="listbox"
+            className="absolute z-10 mt-1 max-h-64 w-full overflow-y-auto border border-gray-700 bg-[#111113]"
+          >
+            {suggestions.map((suggestion, index) => (
+              <li
+                key={suggestion.discordId}
+                role="option"
+                aria-selected={index === activeIndex}
+              >
+                <button
+                  type="button"
+                  // mousedown fires before the input's blur, so the pick lands
+                  onMouseDown={e => {
+                    e.preventDefault();
+                    pick(suggestion.discordId);
+                  }}
+                  onMouseEnter={() => setActiveIndex(index)}
+                  className={`w-full cursor-pointer px-2 py-1.5 text-left text-base ${
+                    index === activeIndex
+                      ? 'bg-sanguine-red/10 text-white'
+                      : 'text-sanguine-bright'
+                  }`}
+                >
+                  {suggestion.nickname}
+                </button>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/components/TileArt.tsx
+++ b/app/components/TileArt.tsx
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+/**
+ * Ghosted boss/activity artwork behind a tile-race task tile, shared by the
+ * public board and the admin board builder. Sits under the tile text at low
+ * opacity, and unmounts itself if the keyword-guessed wiki image 404s so a
+ * broken-image glyph never shows.
+ */
+export function TileArt({ src }: { src: string }) {
+  const [failed, setFailed] = useState(false);
+
+  if (failed) {
+    return null;
+  }
+
+  return (
+    <img
+      src={src}
+      alt=""
+      aria-hidden
+      loading="lazy"
+      onError={() => setFailed(true)}
+      className="pointer-events-none absolute inset-0 m-auto max-h-[70%] max-w-[75%] object-contain opacity-35"
+    />
+  );
+}

--- a/app/components/TileImagePicker.tsx
+++ b/app/components/TileImagePicker.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useRef, useState } from 'react';
+import { useFetcher } from '@remix-run/react';
+import { Text } from '@radix-ui/themes';
+import { Input } from '~/components/input';
+import type { ITileImageOption } from '~/utils/tile-image-catalog';
+
+interface ITileImagePickerProps {
+  /** Currently selected wiki image URL, if any. */
+  value?: string;
+  onChange: (imageUrl: string | undefined) => void;
+  id?: string;
+}
+
+const DEBOUNCE_MS = 250;
+
+// "https://.../images/Great_Olm.png" -> "Great Olm"
+const labelFromUrl = (url: string): string => {
+  const file = url.split('/').pop() ?? url;
+  return decodeURIComponent(file)
+    .replace(/\.(png|gif|jpg)$/i, '')
+    .replace(/_/g, ' ');
+};
+
+/**
+ * Typeahead single-select over OSRS artwork (bosses/activities + any item),
+ * backed by the staff-only /admin/image-search resource route. The selection
+ * shows as a thumbnail chip with a clear button; the chosen URL reaches the
+ * form via the parent's tile state, not a hidden input of its own.
+ */
+export function TileImagePicker({ value, onChange, id }: ITileImagePickerProps) {
+  const fetcher = useFetcher<{ results: ITileImageOption[] }>();
+  const [query, setQuery] = useState('');
+  const [activeIndex, setActiveIndex] = useState(0);
+  const debounceRef = useRef<ReturnType<typeof setTimeout>>();
+
+  const trimmed = query.trim();
+  useEffect(() => {
+    if (trimmed.length < 2) {
+      return;
+    }
+    debounceRef.current = setTimeout(() => {
+      fetcher.load(`/admin/image-search?q=${encodeURIComponent(trimmed)}`);
+    }, DEBOUNCE_MS);
+    return () => clearTimeout(debounceRef.current);
+    // fetcher identity changes across loads; keying the effect on it would re-fire endlessly
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [trimmed]);
+
+  const suggestions = trimmed.length < 2 ? [] : (fetcher.data?.results ?? []);
+
+  const pick = (option: ITileImageOption) => {
+    onChange(option.imageUrl);
+    setQuery('');
+    setActiveIndex(0);
+  };
+
+  const onKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      setActiveIndex(i => Math.min(i + 1, suggestions.length - 1));
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      setActiveIndex(i => Math.max(i - 1, 0));
+    } else if (e.key === 'Enter' && suggestions.length) {
+      // Swallow the submit only while choosing a suggestion
+      e.preventDefault();
+      pick(suggestions[Math.min(activeIndex, suggestions.length - 1)]);
+    } else if (e.key === 'Escape' && trimmed) {
+      e.preventDefault();
+      setQuery('');
+    }
+  };
+
+  if (value) {
+    return (
+      <span className="flex w-fit items-center gap-2 rounded-sm border border-gray-700 bg-gray-900 py-1 pl-2 pr-1">
+        <img
+          src={value}
+          alt=""
+          className="h-6 w-6 object-contain"
+          loading="lazy"
+        />
+        <Text size="3" className="text-gray-100">
+          {labelFromUrl(value)}
+        </Text>
+        <button
+          type="button"
+          onClick={() => onChange(undefined)}
+          aria-label="Remove image"
+          className="cursor-pointer px-1 text-gray-500 hover:text-white"
+        >
+          ×
+        </button>
+      </span>
+    );
+  }
+
+  return (
+    <div className="relative">
+      <Input
+        id={id}
+        value={query}
+        onChange={e => {
+          setQuery(e.target.value);
+          setActiveIndex(0);
+        }}
+        onKeyDown={onKeyDown}
+        onBlur={() => setQuery('')}
+        placeholder="Search a boss or item…"
+        className="text-base"
+        autoComplete="off"
+        role="combobox"
+        aria-expanded={suggestions.length > 0}
+        aria-autocomplete="list"
+      />
+      {suggestions.length > 0 && (
+        <ul
+          role="listbox"
+          className="absolute z-10 mt-1 max-h-64 w-full overflow-y-auto border border-gray-700 bg-[#111113]"
+        >
+          {suggestions.map((suggestion, index) => (
+            <li
+              key={suggestion.imageUrl}
+              role="option"
+              aria-selected={index === activeIndex}
+            >
+              <button
+                type="button"
+                // mousedown fires before the input's blur, so the pick lands
+                onMouseDown={e => {
+                  e.preventDefault();
+                  pick(suggestion);
+                }}
+                onMouseEnter={() => setActiveIndex(index)}
+                className={`flex w-full cursor-pointer items-center gap-2 px-2 py-1.5 text-left text-base ${
+                  index === activeIndex
+                    ? 'bg-sanguine-red/10 text-white'
+                    : 'text-gray-200'
+                }`}
+              >
+                <img
+                  src={suggestion.imageUrl}
+                  alt=""
+                  className="h-6 w-6 object-contain"
+                  loading="lazy"
+                />
+                {suggestion.label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/components/TileRaceBoardBuilder.tsx
+++ b/app/components/TileRaceBoardBuilder.tsx
@@ -100,7 +100,7 @@ export function TileRaceBoardBuilder({ tiles, onChange }: ITileRaceBoardBuilderP
       </Box>
 
       {selectedTile && selected !== null && (
-        <Box mt="3" className="rounded-sm border border-gray-700 p-3">
+        <Box mt="3" className="border-t-2 border-t-sanguine-red bg-sanguine-red/[0.04] p-3">
           <Flex align="center" justify="between" gap="3" wrap="wrap">
             <Text size="2" className="text-osrs-orange">
               Tile {selected + 1} of {tiles.length}

--- a/app/components/TileRaceBoardBuilder.tsx
+++ b/app/components/TileRaceBoardBuilder.tsx
@@ -27,7 +27,10 @@ type BuilderCell =
 
 const NEW_TILE: IBoardTileInput = { type: 'TASK', name: '' };
 
-export function TileRaceBoardBuilder({ tiles, onChange }: ITileRaceBoardBuilderProps) {
+export function TileRaceBoardBuilder({
+  tiles,
+  onChange,
+}: ITileRaceBoardBuilderProps) {
   const [selected, setSelected] = useState<number | null>(null);
 
   const cells: BuilderCell[] = [
@@ -39,7 +42,9 @@ export function TileRaceBoardBuilder({ tiles, onChange }: ITileRaceBoardBuilderP
   const rows = chunkIntoSnakeRows(cells, BOARD_COLUMNS);
 
   const updateTile = (index: number, patch: Partial<IBoardTileInput>) =>
-    onChange(tiles.map((tile, i) => (i === index ? { ...tile, ...patch } : tile)));
+    onChange(
+      tiles.map((tile, i) => (i === index ? { ...tile, ...patch } : tile)),
+    );
 
   const appendTile = () => {
     onChange([...tiles, NEW_TILE]);
@@ -47,7 +52,11 @@ export function TileRaceBoardBuilder({ tiles, onChange }: ITileRaceBoardBuilderP
   };
 
   const insertAfter = (index: number) => {
-    onChange([...tiles.slice(0, index + 1), NEW_TILE, ...tiles.slice(index + 1)]);
+    onChange([
+      ...tiles.slice(0, index + 1),
+      NEW_TILE,
+      ...tiles.slice(index + 1),
+    ]);
     setSelected(index + 1);
   };
 
@@ -100,32 +109,66 @@ export function TileRaceBoardBuilder({ tiles, onChange }: ITileRaceBoardBuilderP
       </Box>
 
       {selectedTile && selected !== null && (
-        <Box mt="3" className="border-t-2 border-t-sanguine-red bg-sanguine-red/[0.04] p-3">
+        <Box
+          mt="3"
+          className="border-t-2 border-t-sanguine-red bg-sanguine-red/[0.04] p-3"
+        >
           <Flex align="center" justify="between" gap="3" wrap="wrap">
-            <Text size="2" className="text-osrs-orange">
+            <Text size="3" className="text-osrs-orange">
               Tile {selected + 1} of {tiles.length}
             </Text>
-            <Flex gap="2">
-              <Button size="1" variant="soft" type="button" className="cursor-pointer" onClick={() => moveTile(selected, -1)} disabled={selected === 0}>
+            <Flex gap="2" wrap="wrap">
+              <Button
+                size="2"
+                variant="soft"
+                type="button"
+                className="cursor-pointer"
+                onClick={() => moveTile(selected, -1)}
+                disabled={selected === 0}
+              >
                 ◀ Move
               </Button>
-              <Button size="1" variant="soft" type="button" className="cursor-pointer" onClick={() => moveTile(selected, 1)} disabled={selected === tiles.length - 1}>
+              <Button
+                size="2"
+                variant="soft"
+                type="button"
+                className="cursor-pointer"
+                onClick={() => moveTile(selected, 1)}
+                disabled={selected === tiles.length - 1}
+              >
                 Move ▶
               </Button>
-              <Button size="1" variant="soft" type="button" className="cursor-pointer" onClick={() => insertAfter(selected)}>
+              <Button
+                size="2"
+                variant="soft"
+                type="button"
+                className="cursor-pointer"
+                onClick={() => insertAfter(selected)}
+              >
                 Insert after
               </Button>
-              <Button size="1" color="red" variant="soft" type="button" className="cursor-pointer" onClick={() => removeTile(selected)}>
+              <Button
+                size="2"
+                color="red"
+                variant="soft"
+                type="button"
+                className="cursor-pointer"
+                onClick={() => removeTile(selected)}
+              >
                 Delete
               </Button>
             </Flex>
           </Flex>
           <Flex mt="3" gap="4" wrap="wrap" align="end">
             <div className="flex flex-col gap-1.5">
-              <Label htmlFor="tileType">Type</Label>
+              <Label className="text-base" htmlFor="tileType">
+                Type
+              </Label>
               <Select.Root
                 value={selectedTile.type}
-                onValueChange={value => changeType(selected, value as BoardTileInputType)}
+                onValueChange={value =>
+                  changeType(selected, value as BoardTileInputType)
+                }
               >
                 <Select.Trigger id="tileType" className="min-w-40" />
                 <Select.Content>
@@ -138,37 +181,53 @@ export function TileRaceBoardBuilder({ tiles, onChange }: ITileRaceBoardBuilderP
             {selectedTile.type === 'TASK' ? (
               <>
                 <div className="flex min-w-64 flex-1 flex-col gap-1.5">
-                  <Label htmlFor="tileName">Task name</Label>
+                  <Label className="text-base" htmlFor="tileName">
+                    Task name
+                  </Label>
                   <Input
                     id="tileName"
                     value={selectedTile.name ?? ''}
-                    onChange={e => updateTile(selected, { name: e.target.value })}
+                    onChange={e =>
+                      updateTile(selected, { name: e.target.value })
+                    }
                     placeholder="50KC @ Vorkath"
+                    className="text-base"
                     maxLength={100}
                   />
                 </div>
                 <div className="flex min-w-64 flex-1 flex-col gap-1.5">
-                  <Label htmlFor="tileDescription">Description (optional)</Label>
+                  <Label className="text-base" htmlFor="tileDescription">
+                    Description (optional)
+                  </Label>
                   <Input
                     id="tileDescription"
                     value={selectedTile.description ?? ''}
-                    onChange={e => updateTile(selected, { description: e.target.value })}
+                    onChange={e =>
+                      updateTile(selected, { description: e.target.value })
+                    }
                     placeholder="Any team member reaches 50 KC gained during the event"
+                    className="text-base"
                     maxLength={300}
                   />
                 </div>
               </>
             ) : (
               <div className="flex flex-col gap-1.5">
-                <Label htmlFor="tileAmount">Tiles</Label>
+                <Label className="text-base" htmlFor="tileAmount">
+                  Tiles
+                </Label>
                 <Input
                   id="tileAmount"
                   type="number"
                   min={1}
                   max={20}
                   value={selectedTile.amount ?? 1}
-                  onChange={e => updateTile(selected, { amount: Math.max(1, Number(e.target.value) || 1) })}
-                  className="w-24"
+                  onChange={e =>
+                    updateTile(selected, {
+                      amount: Math.max(1, Number(e.target.value) || 1),
+                    })
+                  }
+                  className="w-24 text-base"
                 />
               </div>
             )}
@@ -200,7 +259,7 @@ function BuilderCellView({
   if (cell.kind === 'start' || cell.kind === 'finish') {
     return (
       <div className={`${CELL_BASE} border-gray-800 bg-gray-900`}>
-        <span className="text-[11px] text-green-400">
+        <span className="text-xs text-green-400">
           {cell.kind === 'start' ? 'START' : 'FINISH'}
         </span>
       </div>
@@ -223,13 +282,21 @@ function BuilderCellView({
   const { tile, index } = cell;
   const content =
     tile.type === 'GO_BACK' ? (
-      <span className="text-[10px] leading-tight text-red-400">Go back {tile.amount}</span>
+      <span className="text-[11px] leading-tight text-red-400">
+        Go back {tile.amount}
+      </span>
     ) : tile.type === 'GO_FORWARD' ? (
-      <span className="text-[10px] leading-tight text-sky-400">Forward {tile.amount}</span>
+      <span className="text-[11px] leading-tight text-sky-400">
+        Forward {tile.amount}
+      </span>
     ) : tile.name?.trim() ? (
-      <span className="text-[10px] leading-tight text-gray-200">{tile.name}</span>
+      <span className="text-[11px] leading-tight text-gray-200">
+        {tile.name}
+      </span>
     ) : (
-      <span className="text-[10px] leading-tight text-gray-500">(unnamed task)</span>
+      <span className="text-[11px] leading-tight text-gray-500">
+        (unnamed task)
+      </span>
     );
 
   return (
@@ -243,7 +310,9 @@ function BuilderCellView({
           : 'border-gray-800 bg-gray-900 hover:border-gray-500'
       }`}
     >
-      <span className="absolute left-1 top-0.5 text-[9px] text-gray-600">{index + 1}</span>
+      <span className="absolute left-1 top-0.5 text-[10px] text-gray-600">
+        {index + 1}
+      </span>
       {content}
     </button>
   );

--- a/app/components/TileRaceBoardBuilder.tsx
+++ b/app/components/TileRaceBoardBuilder.tsx
@@ -1,0 +1,250 @@
+import { useState } from 'react';
+import { Box, Button, Flex, Select, Text } from '@radix-ui/themes';
+import {
+  BOARD_COLUMNS,
+  BoardTileInputType,
+  chunkIntoSnakeRows,
+  IBoardTileInput,
+} from '~/utils/tile-race-board';
+import { Input } from '~/components/input';
+import { Label } from '~/components/label';
+
+/**
+ * Click-to-build board editor that renders exactly like the public race page:
+ * the ＋ tile appends, clicking a tile selects it for editing below the grid.
+ * START and FINISH are fixed — the events service adds them around these tiles.
+ */
+interface ITileRaceBoardBuilderProps {
+  tiles: IBoardTileInput[];
+  onChange: (tiles: IBoardTileInput[]) => void;
+}
+
+type BuilderCell =
+  | { kind: 'start' }
+  | { kind: 'finish' }
+  | { kind: 'add' }
+  | { kind: 'tile'; tile: IBoardTileInput; index: number };
+
+const NEW_TILE: IBoardTileInput = { type: 'TASK', name: '' };
+
+export function TileRaceBoardBuilder({ tiles, onChange }: ITileRaceBoardBuilderProps) {
+  const [selected, setSelected] = useState<number | null>(null);
+
+  const cells: BuilderCell[] = [
+    { kind: 'start' },
+    ...tiles.map((tile, index) => ({ kind: 'tile' as const, tile, index })),
+    { kind: 'add' },
+    { kind: 'finish' },
+  ];
+  const rows = chunkIntoSnakeRows(cells, BOARD_COLUMNS);
+
+  const updateTile = (index: number, patch: Partial<IBoardTileInput>) =>
+    onChange(tiles.map((tile, i) => (i === index ? { ...tile, ...patch } : tile)));
+
+  const appendTile = () => {
+    onChange([...tiles, NEW_TILE]);
+    setSelected(tiles.length);
+  };
+
+  const insertAfter = (index: number) => {
+    onChange([...tiles.slice(0, index + 1), NEW_TILE, ...tiles.slice(index + 1)]);
+    setSelected(index + 1);
+  };
+
+  const removeTile = (index: number) => {
+    onChange(tiles.filter((_, i) => i !== index));
+    setSelected(null);
+  };
+
+  const moveTile = (index: number, delta: -1 | 1) => {
+    const target = index + delta;
+    if (target < 0 || target >= tiles.length) {
+      return;
+    }
+    const next = tiles.map((tile, i) =>
+      i === index ? tiles[target] : i === target ? tiles[index] : tile,
+    );
+    onChange(next);
+    setSelected(target);
+  };
+
+  const changeType = (index: number, type: BoardTileInputType) => {
+    const tile = tiles[index];
+    onChange(
+      tiles.map((t, i) =>
+        i === index
+          ? type === 'TASK'
+            ? { type, name: tile.name ?? '', description: tile.description }
+            : { type, amount: tile.amount ?? 1 }
+          : t,
+      ),
+    );
+  };
+
+  const selectedTile = selected !== null ? tiles[selected] : null;
+
+  return (
+    <Box>
+      <Box className="overflow-x-auto">
+        <div className="grid min-w-[40rem] grid-cols-10 gap-1">
+          {rows.flat().map((cell, i) => (
+            <BuilderCellView
+              key={i}
+              cell={cell}
+              selected={cell?.kind === 'tile' && cell.index === selected}
+              onAppend={appendTile}
+              onSelect={index => setSelected(index === selected ? null : index)}
+            />
+          ))}
+        </div>
+      </Box>
+
+      {selectedTile && selected !== null && (
+        <Box mt="3" className="rounded-sm border border-gray-700 p-3">
+          <Flex align="center" justify="between" gap="3" wrap="wrap">
+            <Text size="2" className="text-osrs-orange">
+              Tile {selected + 1} of {tiles.length}
+            </Text>
+            <Flex gap="2">
+              <Button size="1" variant="soft" type="button" className="cursor-pointer" onClick={() => moveTile(selected, -1)} disabled={selected === 0}>
+                ◀ Move
+              </Button>
+              <Button size="1" variant="soft" type="button" className="cursor-pointer" onClick={() => moveTile(selected, 1)} disabled={selected === tiles.length - 1}>
+                Move ▶
+              </Button>
+              <Button size="1" variant="soft" type="button" className="cursor-pointer" onClick={() => insertAfter(selected)}>
+                Insert after
+              </Button>
+              <Button size="1" color="red" variant="soft" type="button" className="cursor-pointer" onClick={() => removeTile(selected)}>
+                Delete
+              </Button>
+            </Flex>
+          </Flex>
+          <Flex mt="3" gap="4" wrap="wrap" align="end">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="tileType">Type</Label>
+              <Select.Root
+                value={selectedTile.type}
+                onValueChange={value => changeType(selected, value as BoardTileInputType)}
+              >
+                <Select.Trigger id="tileType" className="min-w-40" />
+                <Select.Content>
+                  <Select.Item value="TASK">Task</Select.Item>
+                  <Select.Item value="GO_BACK">Go back</Select.Item>
+                  <Select.Item value="GO_FORWARD">Go forward</Select.Item>
+                </Select.Content>
+              </Select.Root>
+            </div>
+            {selectedTile.type === 'TASK' ? (
+              <>
+                <div className="flex min-w-64 flex-1 flex-col gap-1.5">
+                  <Label htmlFor="tileName">Task name</Label>
+                  <Input
+                    id="tileName"
+                    value={selectedTile.name ?? ''}
+                    onChange={e => updateTile(selected, { name: e.target.value })}
+                    placeholder="50KC @ Vorkath"
+                    maxLength={100}
+                  />
+                </div>
+                <div className="flex min-w-64 flex-1 flex-col gap-1.5">
+                  <Label htmlFor="tileDescription">Description (optional)</Label>
+                  <Input
+                    id="tileDescription"
+                    value={selectedTile.description ?? ''}
+                    onChange={e => updateTile(selected, { description: e.target.value })}
+                    placeholder="Any team member reaches 50 KC gained during the event"
+                    maxLength={300}
+                  />
+                </div>
+              </>
+            ) : (
+              <div className="flex flex-col gap-1.5">
+                <Label htmlFor="tileAmount">Tiles</Label>
+                <Input
+                  id="tileAmount"
+                  type="number"
+                  min={1}
+                  max={20}
+                  value={selectedTile.amount ?? 1}
+                  onChange={e => updateTile(selected, { amount: Math.max(1, Number(e.target.value) || 1) })}
+                  className="w-24"
+                />
+              </div>
+            )}
+          </Flex>
+        </Box>
+      )}
+    </Box>
+  );
+}
+
+const CELL_BASE =
+  'relative flex aspect-square flex-col items-center justify-center overflow-hidden rounded-sm border p-1 text-center';
+
+function BuilderCellView({
+  cell,
+  selected,
+  onAppend,
+  onSelect,
+}: {
+  cell: BuilderCell | null;
+  selected: boolean;
+  onAppend: () => void;
+  onSelect: (index: number) => void;
+}) {
+  if (!cell) {
+    return <div aria-hidden />;
+  }
+
+  if (cell.kind === 'start' || cell.kind === 'finish') {
+    return (
+      <div className={`${CELL_BASE} border-gray-800 bg-gray-900`}>
+        <span className="text-[11px] text-green-400">
+          {cell.kind === 'start' ? 'START' : 'FINISH'}
+        </span>
+      </div>
+    );
+  }
+
+  if (cell.kind === 'add') {
+    return (
+      <button
+        type="button"
+        onClick={onAppend}
+        className={`${CELL_BASE} cursor-pointer border-dashed border-gray-600 bg-gray-900 hover:border-gray-400`}
+        title="Add a tile"
+      >
+        <span className="text-lg text-gray-400">＋</span>
+      </button>
+    );
+  }
+
+  const { tile, index } = cell;
+  const content =
+    tile.type === 'GO_BACK' ? (
+      <span className="text-[10px] leading-tight text-red-400">Go back {tile.amount}</span>
+    ) : tile.type === 'GO_FORWARD' ? (
+      <span className="text-[10px] leading-tight text-sky-400">Forward {tile.amount}</span>
+    ) : tile.name?.trim() ? (
+      <span className="text-[10px] leading-tight text-gray-200">{tile.name}</span>
+    ) : (
+      <span className="text-[10px] leading-tight text-gray-500">(unnamed task)</span>
+    );
+
+  return (
+    <button
+      type="button"
+      onClick={() => onSelect(index)}
+      title={tile.description || tile.name || undefined}
+      className={`${CELL_BASE} cursor-pointer ${
+        selected
+          ? 'border-sanguine-red bg-sanguine-red/10'
+          : 'border-gray-800 bg-gray-900 hover:border-gray-500'
+      }`}
+    >
+      <span className="absolute left-1 top-0.5 text-[9px] text-gray-600">{index + 1}</span>
+      {content}
+    </button>
+  );
+}

--- a/app/components/TileRaceBoardBuilder.tsx
+++ b/app/components/TileRaceBoardBuilder.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { Box, Button, Flex, Select, Text } from '@radix-ui/themes';
+import { Box, Flex, Select, Text } from '@radix-ui/themes';
+import { Button } from '~/components/button';
 import {
   BOARD_COLUMNS,
   BoardTileInputType,
@@ -8,6 +9,9 @@ import {
 } from '~/utils/tile-race-board';
 import { Input } from '~/components/input';
 import { Label } from '~/components/label';
+import { getTileImageUrl } from '~/utils/tile-race-images';
+import { TileArt } from '~/components/TileArt';
+import { TileImagePicker } from '~/components/TileImagePicker';
 
 /**
  * Click-to-build board editor that renders exactly like the public race page:
@@ -119,40 +123,25 @@ export function TileRaceBoardBuilder({
             </Text>
             <Flex gap="2" wrap="wrap">
               <Button
-                size="2"
-                variant="soft"
                 type="button"
-                className="cursor-pointer"
                 onClick={() => moveTile(selected, -1)}
                 disabled={selected === 0}
               >
                 ◀ Move
               </Button>
               <Button
-                size="2"
-                variant="soft"
                 type="button"
-                className="cursor-pointer"
                 onClick={() => moveTile(selected, 1)}
                 disabled={selected === tiles.length - 1}
               >
                 Move ▶
               </Button>
-              <Button
-                size="2"
-                variant="soft"
-                type="button"
-                className="cursor-pointer"
-                onClick={() => insertAfter(selected)}
-              >
+              <Button type="button" onClick={() => insertAfter(selected)}>
                 Insert after
               </Button>
               <Button
-                size="2"
-                color="red"
-                variant="soft"
+                variant="danger"
                 type="button"
-                className="cursor-pointer"
                 onClick={() => removeTile(selected)}
               >
                 Delete
@@ -208,6 +197,16 @@ export function TileRaceBoardBuilder({
                     placeholder="Any team member reaches 50 KC gained during the event"
                     className="text-base"
                     maxLength={300}
+                  />
+                </div>
+                <div className="flex min-w-64 flex-col gap-1.5">
+                  <Label className="text-base" htmlFor="tileImage">
+                    Image (optional)
+                  </Label>
+                  <TileImagePicker
+                    id="tileImage"
+                    value={selectedTile.imageUrl}
+                    onChange={imageUrl => updateTile(selected, { imageUrl })}
                   />
                 </div>
               </>
@@ -280,6 +279,10 @@ function BuilderCellView({
   }
 
   const { tile, index } = cell;
+  const imageUrl =
+    tile.type === 'TASK'
+      ? (tile.imageUrl ?? getTileImageUrl(tile.name, tile.description))
+      : null;
   const content =
     tile.type === 'GO_BACK' ? (
       <span className="text-[11px] leading-tight text-red-400">
@@ -310,10 +313,12 @@ function BuilderCellView({
           : 'border-gray-800 bg-gray-900 hover:border-gray-500'
       }`}
     >
+      {imageUrl && <TileArt src={imageUrl} />}
       <span className="absolute left-1 top-0.5 text-[10px] text-gray-600">
         {index + 1}
       </span>
-      {content}
+      {/* relative lifts the label above the absolutely-positioned artwork */}
+      <span className="relative">{content}</span>
     </button>
   );
 }

--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+
+import { cn } from '~/utils/misc';
+
+// Flat, square, visibly-bordered buttons per the design system — Radix's soft
+// variant is a ~10%-alpha fill that disappears on the near-black page and
+// reads as a bare text link. Red fill marks the committed action; danger and
+// gold stay outlined so destructive chrome never outweighs the primary.
+const VARIANT_CLASSES = {
+  default:
+    'border-gray-600 bg-gray-800 text-gray-100 enabled:hover:border-gray-400 enabled:hover:bg-gray-700',
+  primary:
+    'border-sanguine-red bg-sanguine-red text-white enabled:hover:border-sanguine-bright enabled:hover:bg-sanguine-bright',
+  danger:
+    'border-sanguine-red/50 bg-gray-900 text-sanguine-bright enabled:hover:border-sanguine-red enabled:hover:bg-sanguine-red/10',
+  gold: 'border-osrs-gold/50 bg-gray-900 text-osrs-gold enabled:hover:border-osrs-gold enabled:hover:bg-osrs-gold/10',
+} as const;
+
+const SIZE_CLASSES = {
+  sm: 'px-2.5 py-1 text-sm',
+  md: 'px-3.5 py-2 text-base',
+} as const;
+
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: keyof typeof VARIANT_CLASSES;
+  size?: keyof typeof SIZE_CLASSES;
+}
+
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
+  ({ className, variant = 'default', size = 'sm', ...props }, ref) => (
+    <button
+      className={cn(
+        'inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-sm border transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-400 disabled:cursor-not-allowed disabled:opacity-50',
+        VARIANT_CLASSES[variant],
+        SIZE_CLASSES[size],
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  ),
+);
+Button.displayName = 'Button';
+
+export { Button };

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -8,6 +8,7 @@ type SubLink = { to: string; label: string };
 const eventsLinks: SubLink[] = [
   { to: '/events', label: 'Events' },
   { to: '/bingo', label: 'Bingo' },
+  { to: '/tile-race', label: 'Tile Race' },
   { to: '/monthly-winners', label: 'Monthly Winners' },
 ];
 

--- a/app/mocks/auth.server.ts
+++ b/app/mocks/auth.server.ts
@@ -1,0 +1,25 @@
+import { redirect } from '@remix-run/node';
+import type { ISessionUser } from '../services/auth.server';
+
+// MOCK_MODE stand-in for Discord OAuth: every visitor is a logged-in staff member.
+
+const mockUser: ISessionUser = {
+  discordId: '111111111111111111',
+  username: 'MockAdmin',
+  avatarUrl: null,
+  isStaff: true,
+};
+
+export const requireStaff = async (): Promise<ISessionUser> => mockUser;
+
+export const getSessionUser = async (): Promise<ISessionUser | null> => mockUser;
+
+export const authenticator = {
+  authenticate: async (): Promise<never> => {
+    throw redirect('/admin');
+  },
+  isAuthenticated: async (): Promise<ISessionUser> => mockUser,
+  logout: async (): Promise<never> => {
+    throw redirect('/');
+  },
+};

--- a/app/mocks/auth.server.ts
+++ b/app/mocks/auth.server.ts
@@ -15,6 +15,7 @@ export const requireStaff = async (): Promise<ISessionUser> => mockUser;
 export const getSessionUser = async (): Promise<ISessionUser | null> => mockUser;
 
 export const authenticator = {
+  sessionErrorKey: 'auth:error',
   authenticate: async (): Promise<never> => {
     throw redirect('/admin');
   },
@@ -22,4 +23,9 @@ export const authenticator = {
   logout: async (): Promise<never> => {
     throw redirect('/');
   },
+};
+
+export const sessionStorage = {
+  getSession: async () => ({ get: (): undefined => undefined }),
+  commitSession: async () => '',
 };

--- a/app/mocks/discord-admin-service.server.ts
+++ b/app/mocks/discord-admin-service.server.ts
@@ -1,0 +1,15 @@
+import type {
+  IGuildMember,
+  IGuildTextChannel,
+} from '../services/discord-admin-service.server';
+
+export const getGuildMember = async (): Promise<IGuildMember | null> => ({
+  roles: ['mock-admin-role'],
+  nick: 'MockAdmin',
+});
+
+export const getGuildTextChannels = async (): Promise<IGuildTextChannel[]> => [
+  { id: '200000000000000001', name: 'event-announcements' },
+  { id: '200000000000000002', name: 'event-approvals' },
+  { id: '200000000000000003', name: 'general' },
+];

--- a/app/mocks/events-admin-service.server.ts
+++ b/app/mocks/events-admin-service.server.ts
@@ -15,13 +15,17 @@ export class EventsApiError extends Error {
   }
 }
 
-export const getAdminRace = async (): Promise<IAdminTileRace | null> => ({
-  ...mockAdminRaceBase,
-  channels: {
-    approvalsChannelId: '200000000000000002',
-    announcementsChannelId: '200000000000000001',
-  },
-});
+// MOCK_EMPTY_RACE=1 makes the portal show the create-race form instead of the dashboard
+export const getAdminRace = async (): Promise<IAdminTileRace | null> =>
+  process.env.MOCK_EMPTY_RACE === '1'
+    ? null
+    : {
+        ...mockAdminRaceBase,
+        channels: {
+          approvalsChannelId: '200000000000000002',
+          announcementsChannelId: '200000000000000001',
+        },
+      };
 
 const ok = async <T>(value: T): Promise<T> => value;
 

--- a/app/mocks/events-admin-service.server.ts
+++ b/app/mocks/events-admin-service.server.ts
@@ -1,0 +1,45 @@
+import type { IAdminTileRace } from '../services/events-admin-service.server';
+import { getCurrentTileRace } from './tile-race-service.server';
+
+// MOCK_MODE stand-in for the sanguine-events admin API: serves the public mock
+// race with admin channel config bolted on; mutations succeed without doing
+// anything (the fixture is static).
+
+export class EventsApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'EventsApiError';
+  }
+}
+
+export const getAdminRace = async (): Promise<IAdminTileRace | null> => {
+  const race = await getCurrentTileRace();
+  return race
+    ? {
+        ...race,
+        channels: {
+          approvalsChannelId: '200000000000000002',
+          announcementsChannelId: '200000000000000001',
+        },
+      }
+    : null;
+};
+
+const ok = async <T>(value: T): Promise<T> => value;
+
+export const createRace = () => ok({ eventId: 'mock-race' });
+export const startRace = () => ok({ started: true, teamCount: 4 });
+export const endRace = async (): Promise<IAdminTileRace> => {
+  const race = await getAdminRace();
+  if (!race) throw new EventsApiError('No open tile race', 404);
+  return race;
+};
+export const cancelRace = () => ok({ cancelled: true });
+export const addTeam = () => ok({ teamId: 'mock-team', name: 'Mock Team' });
+export const removeTeam = () => ok({ removed: true });
+export const moveTeam = () => ok({ tileIndex: 1 });
+export const completeTeamTask = () => ok({ tileIndex: 2 });
+export const rerollTeam = () => ok({ tileIndex: 3 });

--- a/app/mocks/events-admin-service.server.ts
+++ b/app/mocks/events-admin-service.server.ts
@@ -38,6 +38,14 @@ export const endRace = async (): Promise<IAdminTileRace> => {
 };
 export const cancelRace = () => ok({ cancelled: true });
 export const addTeam = () => ok({ teamId: 'mock-team', name: 'Mock Team' });
+export const updateTeam = (
+  name: string,
+  patch: { name?: string; memberDiscordIds?: string[] },
+) =>
+  ok({
+    name: patch.name ?? name,
+    memberDiscordIds: patch.memberDiscordIds ?? [],
+  });
 export const removeTeam = () => ok({ removed: true });
 export const moveTeam = () => ok({ tileIndex: 1 });
 export const completeTeamTask = () => ok({ tileIndex: 2 });

--- a/app/mocks/events-admin-service.server.ts
+++ b/app/mocks/events-admin-service.server.ts
@@ -1,9 +1,9 @@
 import type { IAdminTileRace } from '../services/events-admin-service.server';
-import { getCurrentTileRace } from './tile-race-service.server';
+import { mockAdminRaceBase } from './tile-race-service.server';
 
-// MOCK_MODE stand-in for the sanguine-events admin API: serves the public mock
-// race with admin channel config bolted on; mutations succeed without doing
-// anything (the fixture is static).
+// MOCK_MODE stand-in for the sanguine-events admin API: serves the shared fixture with
+// admin channel config bolted on; mutations succeed without doing anything (the fixture
+// is static).
 
 export class EventsApiError extends Error {
   constructor(
@@ -15,18 +15,13 @@ export class EventsApiError extends Error {
   }
 }
 
-export const getAdminRace = async (): Promise<IAdminTileRace | null> => {
-  const race = await getCurrentTileRace();
-  return race
-    ? {
-        ...race,
-        channels: {
-          approvalsChannelId: '200000000000000002',
-          announcementsChannelId: '200000000000000001',
-        },
-      }
-    : null;
-};
+export const getAdminRace = async (): Promise<IAdminTileRace | null> => ({
+  ...mockAdminRaceBase,
+  channels: {
+    approvalsChannelId: '200000000000000002',
+    announcementsChannelId: '200000000000000001',
+  },
+});
 
 const ok = async <T>(value: T): Promise<T> => value;
 

--- a/app/mocks/nicknames/index.ts
+++ b/app/mocks/nicknames/index.ts
@@ -8,3 +8,9 @@ export const getNicknameById = async (discordId: string) => {
 
 export const getNicknames = async () =>
   MOCK_USERS.map(u => ({ discordId: u.discordId, nickname: u.nickname }));
+
+export const getNicknamesByDiscordIds = async (discordIds: string[]) =>
+  MOCK_USERS.filter(u => discordIds.includes(u.discordId)).map(u => ({
+    discordId: u.discordId,
+    nickname: u.nickname,
+  }));

--- a/app/mocks/osrs-wiki-prices-service.ts
+++ b/app/mocks/osrs-wiki-prices-service.ts
@@ -9,6 +9,18 @@ export interface OSRSItem {
 
 export const wikiItemIconUrl = (): string => '/sanguine_icon.png';
 
+// Deterministic stand-in for the admin image picker's item search
+export const searchItems = async (
+  query: string,
+  limit: number,
+): Promise<{ name: string; icon: string }[]> => {
+  const lower = query.toLocaleLowerCase();
+  return ['Abyssal whip', 'Dragon warhammer', 'Twisted bow', 'Scythe of vitur']
+    .filter(name => name.toLocaleLowerCase().includes(lower))
+    .slice(0, limit)
+    .map(name => ({ name, icon: '/sanguine_icon.png' }));
+};
+
 const itemCache = new Map<number, OSRSItem>();
 
 export const fetchOSRSItem = async (

--- a/app/mocks/tile-race-service.server.ts
+++ b/app/mocks/tile-race-service.server.ts
@@ -1,0 +1,132 @@
+import type {
+  ITileRace,
+  ITileRaceTile,
+} from '../services/tile-race-service.server';
+import { MOCK_USERS } from '~/mocks/fixtures.server';
+
+const roster = (from: number, to: number) =>
+  MOCK_USERS.slice(from, to).map(u => u.discordId);
+
+// Deterministic fixture standing in for the sanguine-events API under MOCK_MODE:
+// a mid-race board with movement tiles, one finished team, one awaiting approval.
+
+const task = (name: string, description?: string): ITileRaceTile => ({
+  index: 0,
+  type: 'TASK',
+  name,
+  description,
+});
+const goBack = (amount: number): ITileRaceTile => ({
+  index: 0,
+  type: 'GO_BACK',
+  amount,
+});
+const goForward = (amount: number): ITileRaceTile => ({
+  index: 0,
+  type: 'GO_FORWARD',
+  amount,
+});
+
+const innerTiles: ITileRaceTile[] = [
+  task('60KC @ Barrows', 'Any team member reaches 60 Barrows KC gained during the event'),
+  task('Any GWD unique', 'Any unique drop from any God Wars Dungeon boss'),
+  task('50KC @ Moons', '50 Moons of Peril completions'),
+  goBack(1),
+  task('Any raid unique', 'Any unique from CoX, ToB, or ToA'),
+  task('Melee fight cave', 'Complete the Fight Caves using only melee'),
+  goForward(3),
+  task('100KC @ Vorkath'),
+  task('Any barrows unique'),
+  task('3000 pts in one Wintertodt game'),
+  goBack(3),
+  task('Reach 6hr log', 'Screenshot the 6 hour login timer'),
+  task('Colosseum unique'),
+  task('50KC @ Scurrius'),
+  task('Any Moons unique'),
+  goForward(2),
+  task('Kill Yard using level 60 gear'),
+  task('150KC @ Vardorvis'),
+  task('Any rev unique'),
+  goBack(2),
+  task('100KC @ Muspah'),
+  task('Nightmare unique'),
+  task('250 combined chompy KC'),
+  task('Any Leviathan unique'),
+  task('Punch Vorkath to death', 'Final blow must be an unarmed punch'),
+];
+
+const boardEnds: Record<'start' | 'finish', ITileRaceTile> = {
+  start: { index: 0, type: 'START', name: 'Start' },
+  finish: { index: 0, type: 'FINISH', name: 'Finish' },
+};
+
+const tiles: ITileRaceTile[] = [
+  boardEnds.start,
+  ...innerTiles,
+  boardEnds.finish,
+].map((tile, index) => ({ ...tile, index }));
+
+const finishIndex = tiles.length - 1;
+
+const race: ITileRace = {
+  event: {
+    id: 'mock-tile-race',
+    name: 'Sanguine Tile Race',
+    status: 'ACTIVE',
+    startDate: '2026-08-01T00:00:00.000Z',
+    endDate: '2026-08-15T00:00:00.000Z',
+  },
+  board: {
+    diceSides: 6,
+    tileCount: innerTiles.length,
+    tiles,
+  },
+  standings: [
+    {
+      teamId: 'team-1',
+      name: 'Blood Reapers',
+      memberDiscordIds: roster(0, 3),
+      place: 1,
+      tileIndex: finishIndex,
+      finishIndex,
+      currentTask: null,
+      moveStatus: 'COMPLETED',
+      isFinished: true,
+    },
+    {
+      teamId: 'team-2',
+      name: 'Scythe Squad',
+      memberDiscordIds: roster(3, 6),
+      place: null,
+      tileIndex: 18,
+      finishIndex,
+      currentTask: '150KC @ Vardorvis',
+      moveStatus: 'PENDING_APPROVAL',
+      isFinished: false,
+    },
+    {
+      teamId: 'team-3',
+      name: 'Gob Squad',
+      memberDiscordIds: roster(6, 8),
+      place: null,
+      tileIndex: 12,
+      finishIndex,
+      currentTask: 'Reach 6hr log',
+      moveStatus: 'PENDING_SUBMISSION',
+      isFinished: false,
+    },
+    {
+      teamId: 'team-4',
+      name: 'Rune Goons',
+      memberDiscordIds: roster(8, 11),
+      place: null,
+      tileIndex: 12,
+      finishIndex,
+      currentTask: 'Reach 6hr log',
+      moveStatus: 'PENDING_SUBMISSION',
+      isFinished: false,
+    },
+  ],
+};
+
+export const getCurrentTileRace = async (): Promise<ITileRace | null> => race;

--- a/app/mocks/tile-race-service.server.ts
+++ b/app/mocks/tile-race-service.server.ts
@@ -41,7 +41,15 @@ const innerTiles: ITileRaceTile[] = [
   task('Any barrows unique'),
   task('3000 pts in one Wintertodt game'),
   goBack(3),
-  task('Reach 6hr log', 'Screenshot the 6 hour login timer'),
+  {
+    // Exercises the admin-picked artwork path: no keyword rule matches this
+    // name, so the art can only come from the explicit imageUrl.
+    index: 0,
+    type: 'TASK',
+    name: 'Reach 6hr log',
+    description: 'Screenshot the 6 hour login timer',
+    imageUrl: 'https://oldschool.runescape.wiki/images/Watch_detail.png',
+  },
   task('Colosseum unique'),
   task('50KC @ Scurrius'),
   task('Any Moons unique'),

--- a/app/mocks/tile-race-service.server.ts
+++ b/app/mocks/tile-race-service.server.ts
@@ -1,7 +1,9 @@
 import type {
   ITileRace,
+  ITileRaceStanding,
   ITileRaceTile,
 } from '../services/tile-race-service.server';
+import type { IAdminTileRace } from '../services/events-admin-service.server';
 import { MOCK_USERS } from '~/mocks/fixtures.server';
 
 const roster = (from: number, to: number) =>
@@ -68,7 +70,11 @@ const tiles: ITileRaceTile[] = [
 
 const finishIndex = tiles.length - 1;
 
-const race: ITileRace = {
+// The fixture is admin-shaped (rosters included); the public mock strips the ids,
+// mirroring what the real API's public serializer does.
+type MockAdminRace = Omit<IAdminTileRace, 'channels'>;
+
+export const mockAdminRaceBase: MockAdminRace = {
   event: {
     id: 'mock-tile-race',
     name: 'Sanguine Tile Race',
@@ -129,4 +135,20 @@ const race: ITileRace = {
   ],
 };
 
-export const getCurrentTileRace = async (): Promise<ITileRace | null> => race;
+const toPublicStanding = (
+  standing: MockAdminRace['standings'][number],
+): ITileRaceStanding => ({
+  teamId: standing.teamId,
+  name: standing.name,
+  place: standing.place,
+  tileIndex: standing.tileIndex,
+  finishIndex: standing.finishIndex,
+  currentTask: standing.currentTask,
+  moveStatus: standing.moveStatus,
+  isFinished: standing.isFinished,
+});
+
+export const getCurrentTileRace = async (): Promise<ITileRace | null> => ({
+  ...mockAdminRaceBase,
+  standings: mockAdminRaceBase.standings.map(toPublicStanding),
+});

--- a/app/routes/admin._index.tsx
+++ b/app/routes/admin._index.tsx
@@ -1,4 +1,90 @@
-import { redirect } from '@remix-run/node';
+import { json, LoaderFunctionArgs } from '@remix-run/node';
+import { Link, useLoaderData } from '@remix-run/react';
+import { Box, Flex, Text } from '@radix-ui/themes';
+import { SectionHeading } from '~/components/SectionHeading';
+import { requireStaff } from '~/services/auth.server';
+import { getAdminRace } from '~/services/events-admin-service.server';
 
-// The tile race is the only admin surface today; go straight to it.
-export const loader = () => redirect('/admin/tile-race');
+// Landing for /admin: one row per event surface with its live state. The race is
+// field-picked so team rosters (Discord ids) never reach the browser.
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requireStaff(request);
+  try {
+    const race = await getAdminRace();
+    return json({
+      apiUp: true,
+      race: race
+        ? {
+            name: race.event.name,
+            status: race.event.status,
+            teamCount: race.standings.length,
+            finishedCount: race.standings.filter(s => s.isFinished).length,
+          }
+        : null,
+    });
+  } catch {
+    return json({ apiUp: false, race: null });
+  }
+}
+
+export default function AdminIndex() {
+  const { race, apiUp } = useLoaderData<typeof loader>();
+
+  return (
+    <Box>
+      <SectionHeading title="Events" />
+      <div className="mt-2">
+        <Link
+          to="/admin/tile-race"
+          className="group block border-b border-gray-800 py-3 hover:bg-sanguine-red/[0.04]"
+        >
+          <Flex align="baseline" justify="between" gap="3" wrap="wrap">
+            <Text
+              size="4"
+              className="text-sanguine-bright group-hover:text-white"
+            >
+              Tile race
+            </Text>
+            <Text size="3" className="text-gray-400">
+              {!apiUp ? (
+                <span className="text-red-400">events API unreachable</span>
+              ) : race === null ? (
+                'no open race — create one'
+              ) : race.status === 'DRAFT' ? (
+                <>
+                  {race.name} — draft,{' '}
+                  <span className="text-gray-100">{race.teamCount}</span> team
+                  {race.teamCount === 1 ? '' : 's'}
+                </>
+              ) : (
+                <>
+                  {race.name} — active,{' '}
+                  <span className="text-gray-100">{race.finishedCount}</span> of{' '}
+                  <span className="text-gray-100">{race.teamCount}</span>{' '}
+                  finished
+                </>
+              )}
+            </Text>
+          </Flex>
+          <Text as="p" size="3" className="mt-1 text-gray-500">
+            Dice-roll board race. Build the board, manage teams, start the race,
+            and fix moves when something goes sideways.
+          </Text>
+        </Link>
+        <div className="border-b border-gray-800 py-3">
+          <Flex align="baseline" justify="between" gap="3" wrap="wrap">
+            <Text size="4" className="text-gray-500">
+              Bingo
+            </Text>
+            <Text size="3" className="text-gray-600">
+              planned
+            </Text>
+          </Flex>
+          <Text as="p" size="3" className="mt-1 text-gray-600">
+            Team task boards. Not built yet.
+          </Text>
+        </div>
+      </div>
+    </Box>
+  );
+}

--- a/app/routes/admin._index.tsx
+++ b/app/routes/admin._index.tsx
@@ -1,0 +1,4 @@
+import { redirect } from '@remix-run/node';
+
+// The tile race is the only admin surface today; go straight to it.
+export const loader = () => redirect('/admin/tile-race');

--- a/app/routes/admin.image-search.tsx
+++ b/app/routes/admin.image-search.tsx
@@ -1,0 +1,33 @@
+import { json, LoaderFunctionArgs } from '@remix-run/node';
+import { requireStaff } from '~/services/auth.server';
+import { searchItems } from '~/services/osrs-wiki-prices-service';
+import {
+  ITileImageOption,
+  searchBossImages,
+} from '~/utils/tile-image-catalog';
+
+const MAX_RESULTS = 12;
+
+/**
+ * Resource route backing the tile builder's image picker: bosses/activities
+ * from the curated catalog first, then items from the wiki mapping. Staff-only
+ * — data requests skip the /admin layout gate, so the check lives here too.
+ */
+export async function loader({ request }: LoaderFunctionArgs) {
+  await requireStaff(request);
+  const query = new URL(request.url).searchParams.get('q')?.trim() ?? '';
+  if (query.length < 2) {
+    return json({ results: [] as ITileImageOption[] });
+  }
+
+  const bosses = searchBossImages(query, MAX_RESULTS);
+  const items = await searchItems(query, MAX_RESULTS - bosses.length).catch(
+    () => [],
+  );
+  return json({
+    results: [
+      ...bosses,
+      ...items.map(item => ({ label: item.name, imageUrl: item.icon })),
+    ].slice(0, MAX_RESULTS),
+  });
+}

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -80,7 +80,10 @@ const resolveMemberIds = async (
   ];
   const users = await getUsersWithNicknames();
   const idByNickname = new Map(
-    users.map(user => [user.nickname?.toLocaleLowerCase() ?? '', user.discordId]),
+    users.map(user => [
+      user.nickname?.toLocaleLowerCase() ?? '',
+      user.discordId,
+    ]),
   );
   const resolved = tokens.map(token => ({
     token,
@@ -107,17 +110,25 @@ export async function action({ request }: ActionFunctionArgs) {
         try {
           tiles = JSON.parse(String(formData.get('board') ?? ''));
         } catch {
-          return json({ intent, errors: ['The board payload was malformed.'] }, { status: 400 });
+          return json(
+            { intent, errors: ['The board payload was malformed.'] },
+            { status: 400 },
+          );
         }
         if (!Array.isArray(tiles) || !tiles.length) {
-          return json({ intent, errors: ['Add at least one tile to the board.'] }, { status: 400 });
+          return json(
+            { intent, errors: ['Add at least one tile to the board.'] },
+            { status: 400 },
+          );
         }
         await createRace(
           {
             name: String(formData.get('name') ?? '').trim(),
             diceSides: Number(formData.get('diceSides') ?? 6),
             tiles,
-            approvalsChannelId: String(formData.get('approvalsChannelId') ?? ''),
+            approvalsChannelId: String(
+              formData.get('approvalsChannelId') ?? '',
+            ),
             announcementsChannelId: String(
               formData.get('announcementsChannelId') ?? '',
             ),
@@ -140,7 +151,11 @@ export async function action({ request }: ActionFunctionArgs) {
             { status: 400 },
           );
         }
-        await addTeam(String(formData.get('name') ?? '').trim(), ids, user.discordId);
+        await addTeam(
+          String(formData.get('name') ?? '').trim(),
+          ids,
+          user.discordId,
+        );
         return json({ intent, errors: null });
       }
       case 'removeteam':
@@ -175,10 +190,14 @@ export async function action({ request }: ActionFunctionArgs) {
     // surface them inline like API errors instead of crashing to the error boundary
     if (
       e instanceof TypeError ||
-      (e instanceof Error && (e.name === 'TimeoutError' || e.name === 'AbortError'))
+      (e instanceof Error &&
+        (e.name === 'TimeoutError' || e.name === 'AbortError'))
     ) {
       return json(
-        { intent, errors: ['The events API is unreachable — try again shortly.'] },
+        {
+          intent,
+          errors: ['The events API is unreachable — try again shortly.'],
+        },
         { status: 503 },
       );
     }
@@ -220,17 +239,31 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
 
   return (
     <Box>
-      <SectionHeading title="New tile race" summary="no race is currently open" />
+      <SectionHeading
+        title="New tile race"
+        summary="no race is currently open"
+      />
       <Form method="post" className="mt-4 flex flex-col gap-4">
         <input type="hidden" name="intent" value="create" />
         <input type="hidden" name="board" value={JSON.stringify(tiles)} />
         <div className={fieldClass}>
-          <Label htmlFor="name">Event name</Label>
-          <Input id="name" name="name" required maxLength={100} placeholder="Sanguine Tile Race III" />
+          <Label className="text-base" htmlFor="name">
+            Event name
+          </Label>
+          <Input
+            id="name"
+            name="name"
+            required
+            maxLength={100}
+            className="text-base"
+            placeholder="Sanguine Tile Race III"
+          />
         </div>
         <Flex gap="4" wrap="wrap">
           <div className={fieldClass}>
-            <Label htmlFor="diceSides">Dice sides</Label>
+            <Label className="text-base" htmlFor="diceSides">
+              Dice sides
+            </Label>
             <Input
               id="diceSides"
               name="diceSides"
@@ -238,11 +271,13 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
               min={2}
               max={20}
               defaultValue={6}
-              className="w-24"
+              className="w-24 text-base"
             />
           </div>
           <div className={fieldClass}>
-            <Label htmlFor="days">Planned days</Label>
+            <Label className="text-base" htmlFor="days">
+              Planned days
+            </Label>
             <Input
               id="days"
               name="days"
@@ -250,17 +285,21 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
               min={1}
               max={90}
               defaultValue={14}
-              className="w-24"
+              className="w-24 text-base"
             />
           </div>
         </Flex>
         <Flex gap="4" wrap="wrap">
           <div className={fieldClass}>
-            <Label htmlFor="approvalsChannelId">Approvals channel (private)</Label>
+            <Label className="text-base" htmlFor="approvalsChannelId">
+              Approvals channel (private)
+            </Label>
             <ChannelSelect name="approvalsChannelId" channels={channels} />
           </div>
           <div className={fieldClass}>
-            <Label htmlFor="announcementsChannelId">Announcements channel (public)</Label>
+            <Label className="text-base" htmlFor="announcementsChannelId">
+              Announcements channel (public)
+            </Label>
             <ChannelSelect name="announcementsChannelId" channels={channels} />
           </div>
         </Flex>
@@ -269,8 +308,8 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
             Board — {tiles.length} tile{tiles.length === 1 ? '' : 's'}
           </Label>
           <Text size="1" className="text-gray-500">
-            Click ＋ to add a tile, click a tile to edit it. START and FINISH are
-            added automatically.
+            Click ＋ to add a tile, click a tile to edit it. START and FINISH
+            are added automatically.
           </Text>
           <TileRaceBoardBuilder tiles={tiles} onChange={setTiles} />
         </div>
@@ -350,9 +389,11 @@ function RaceDashboard({
           <span className="text-gray-100">
             {channelName(race.channels.announcementsChannelId)}
           </span>
-          .
-          The public page is{' '}
-          <Link to="/tile-race" className="text-sanguine-bright hover:text-white">
+          . The public page is{' '}
+          <Link
+            to="/tile-race"
+            className="text-sanguine-bright hover:text-white"
+          >
             /tile-race
           </Link>
           .
@@ -360,7 +401,12 @@ function RaceDashboard({
         {event.status === 'DRAFT' && (
           <Form method="post" className="mt-3">
             <input type="hidden" name="intent" value="start" />
-            <Button size="2" type="submit" disabled={submitting} className="cursor-pointer">
+            <Button
+              size="2"
+              type="submit"
+              disabled={submitting}
+              className="cursor-pointer"
+            >
               Start race — roll first tasks
             </Button>
           </Form>
@@ -375,15 +421,24 @@ function RaceDashboard({
         {standings.length === 0 ? (
           <EmptyState>No teams yet — add the first one below.</EmptyState>
         ) : (
-          <Table.Root size="2" mt="2">
+          <Table.Root size="3" mt="2">
             <Table.Header>
               <Table.Row>
-                <Table.ColumnHeaderCell className="text-osrs-orange">Team</Table.ColumnHeaderCell>
-                <Table.ColumnHeaderCell justify="end" className="text-osrs-orange">Tile</Table.ColumnHeaderCell>
+                <Table.ColumnHeaderCell className="text-osrs-orange">
+                  Team
+                </Table.ColumnHeaderCell>
+                <Table.ColumnHeaderCell
+                  justify="end"
+                  className="text-osrs-orange"
+                >
+                  Tile
+                </Table.ColumnHeaderCell>
                 <Table.ColumnHeaderCell className="hidden text-osrs-orange md:table-cell">
                   Current task
                 </Table.ColumnHeaderCell>
-                <Table.ColumnHeaderCell className="text-osrs-orange">Overrides</Table.ColumnHeaderCell>
+                <Table.ColumnHeaderCell className="text-osrs-orange">
+                  Overrides
+                </Table.ColumnHeaderCell>
               </Table.Row>
             </Table.Header>
             <Table.Body>
@@ -406,23 +461,40 @@ function RaceDashboard({
           <Form
             method="post"
             onSubmit={e => {
-              if (!confirm('End the race and post final standings?')) e.preventDefault();
+              if (!confirm('End the race and post final standings?'))
+                e.preventDefault();
             }}
           >
             <input type="hidden" name="intent" value="end" />
-            <Button size="2" color="amber" variant="soft" type="submit" className="cursor-pointer">
+            <Button
+              size="2"
+              color="amber"
+              variant="soft"
+              type="submit"
+              className="cursor-pointer"
+            >
               End race
             </Button>
           </Form>
           <Form
             method="post"
             onSubmit={e => {
-              if (!confirm('Cancel the race? Progress stays in the database but the race is over.'))
+              if (
+                !confirm(
+                  'Cancel the race? Progress stays in the database but the race is over.',
+                )
+              )
                 e.preventDefault();
             }}
           >
             <input type="hidden" name="intent" value="cancel" />
-            <Button size="2" color="red" variant="soft" type="submit" className="cursor-pointer">
+            <Button
+              size="2"
+              color="red"
+              variant="soft"
+              type="submit"
+              className="cursor-pointer"
+            >
               Cancel race
             </Button>
           </Form>
@@ -448,24 +520,24 @@ function TeamRow({
   return (
     <Table.Row className={zebraStripeClass}>
       <Table.Cell>
-        <Text size="2" className="text-gray-100">
+        <Text size="3" className="text-gray-100">
           {standing.name}
         </Text>
       </Table.Cell>
       <Table.Cell justify="end">
         <span className="whitespace-nowrap">
-          <Text size="2" className="text-gray-100">
+          <Text size="3" className="text-gray-100">
             {standing.tileIndex}
           </Text>
-          <Text size="1" className="text-gray-600">
+          <Text size="2" className="text-gray-600">
             {' '}
             / {standing.finishIndex}
           </Text>
         </span>
       </Table.Cell>
       <Table.Cell className="hidden md:table-cell">
-        <Text size="2" className="text-gray-400">
-          {standing.isFinished ? '🏁 Finished' : (standing.currentTask ?? '—')}
+        <Text size="3" className="text-gray-400">
+          {standing.isFinished ? '🏁 Finished' : standing.currentTask ?? '—'}
         </Text>
       </Table.Cell>
       <Table.Cell>
@@ -475,14 +547,26 @@ function TeamRow({
               <fetcher.Form method="post">
                 <input type="hidden" name="intent" value="complete" />
                 <input type="hidden" name="team" value={standing.name} />
-                <Button size="1" variant="soft" type="submit" disabled={busy} className="cursor-pointer">
+                <Button
+                  size="2"
+                  variant="soft"
+                  type="submit"
+                  disabled={busy}
+                  className="cursor-pointer"
+                >
                   Complete task
                 </Button>
               </fetcher.Form>
               <fetcher.Form method="post">
                 <input type="hidden" name="intent" value="reroll" />
                 <input type="hidden" name="team" value={standing.name} />
-                <Button size="1" variant="soft" type="submit" disabled={busy} className="cursor-pointer">
+                <Button
+                  size="2"
+                  variant="soft"
+                  type="submit"
+                  disabled={busy}
+                  className="cursor-pointer"
+                >
                   Reroll
                 </Button>
               </fetcher.Form>
@@ -496,9 +580,15 @@ function TeamRow({
                   max={standing.finishIndex}
                   required
                   placeholder="tile"
-                  className="h-6 w-16 px-1 py-0 text-xs"
+                  className="h-8 w-20 px-2 py-0 text-sm"
                 />
-                <Button size="1" variant="soft" type="submit" disabled={busy} className="cursor-pointer">
+                <Button
+                  size="2"
+                  variant="soft"
+                  type="submit"
+                  disabled={busy}
+                  className="cursor-pointer"
+                >
                   Move
                 </Button>
               </fetcher.Form>
@@ -513,7 +603,14 @@ function TeamRow({
           >
             <input type="hidden" name="intent" value="removeteam" />
             <input type="hidden" name="team" value={standing.name} />
-            <Button size="1" color="red" variant="soft" type="submit" disabled={busy} className="cursor-pointer">
+            <Button
+              size="2"
+              color="red"
+              variant="soft"
+              type="submit"
+              disabled={busy}
+              className="cursor-pointer"
+            >
               Remove
             </Button>
           </fetcher.Form>
@@ -531,29 +628,45 @@ function AddTeamForm() {
 
   return (
     <Box mt="4" className="max-w-xl">
-      <Text as="p" size="3" className="text-osrs-orange">
+      <Text as="p" size="4" className="text-osrs-orange">
         Add a team
       </Text>
       <Form method="post" className="mt-2 flex flex-col gap-3">
         <input type="hidden" name="intent" value="addteam" />
         <div className={fieldClass}>
-          <Label htmlFor="teamName">Team name</Label>
-          <Input id="teamName" name="name" required maxLength={50} placeholder="Blood Reapers" />
+          <Label className="text-base" htmlFor="teamName">
+            Team name
+          </Label>
+          <Input
+            id="teamName"
+            name="name"
+            required
+            maxLength={50}
+            className="text-base"
+            placeholder="Blood Reapers"
+          />
         </div>
         <div className={fieldClass}>
-          <Label htmlFor="members">Members — OSRS names or Discord ids, one per line</Label>
+          <Label className="text-base" htmlFor="members">
+            Members — OSRS names or Discord ids, one per line
+          </Label>
           <textarea
             id="members"
             name="members"
             required
             rows={4}
-            className="rounded-sm border border-gray-700 bg-gray-900 p-2 text-sm text-gray-100 placeholder:text-gray-600"
+            className="rounded-sm border border-gray-700 bg-gray-900 p-2 text-base text-gray-100 placeholder:text-gray-600"
           />
         </div>
         {actionData?.intent === 'addteam' && actionData.errors && (
           <ActionErrors errors={actionData.errors} />
         )}
-        <Button size="2" type="submit" disabled={submitting} className="w-fit cursor-pointer">
+        <Button
+          size="2"
+          type="submit"
+          disabled={submitting}
+          className="w-fit cursor-pointer"
+        >
           Add team
         </Button>
       </Form>
@@ -565,7 +678,7 @@ function ActionErrors({ errors }: { errors: string[] }) {
   return (
     <Box mt="2">
       {errors.map(error => (
-        <Text key={error} as="p" size="2" className="text-red-400">
+        <Text key={error} as="p" size="3" className="text-red-400">
           {error}
         </Text>
       ))}

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -12,6 +12,7 @@ import {
   useLoaderData,
   useNavigation,
 } from '@remix-run/react';
+import { useState } from 'react';
 import { Box, Button, Flex, Select, Table, Text } from '@radix-ui/themes';
 import { requireStaff } from '~/services/auth.server';
 import {
@@ -33,12 +34,10 @@ import {
   IGuildTextChannel,
 } from '~/services/discord-admin-service.server';
 import { getUsersWithNicknames } from '~/services/sanguine-service.server';
-import {
-  BOARD_SCRIPT_PLACEHOLDER,
-  parseBoardScript,
-} from '~/utils/tile-race-board';
+import { IBoardTileInput } from '~/utils/tile-race-board';
 import { Input } from '~/components/input';
 import { Label } from '~/components/label';
+import { TileRaceBoardBuilder } from '~/components/TileRaceBoardBuilder';
 import { SectionHeading } from '~/components/SectionHeading';
 import { EmptyState } from '~/components/EmptyState';
 import { zebraStripeClass } from '~/utils/styles';
@@ -104,15 +103,20 @@ export async function action({ request }: ActionFunctionArgs) {
   try {
     switch (intent) {
       case 'create': {
-        const board = parseBoardScript(String(formData.get('board') ?? ''));
-        if (!board.ok) {
-          return json({ intent, errors: board.errors }, { status: 400 });
+        let tiles: IBoardTileInput[];
+        try {
+          tiles = JSON.parse(String(formData.get('board') ?? ''));
+        } catch {
+          return json({ intent, errors: ['The board payload was malformed.'] }, { status: 400 });
+        }
+        if (!Array.isArray(tiles) || !tiles.length) {
+          return json({ intent, errors: ['Add at least one tile to the board.'] }, { status: 400 });
         }
         await createRace(
           {
             name: String(formData.get('name') ?? '').trim(),
             diceSides: Number(formData.get('diceSides') ?? 6),
-            tiles: board.tiles,
+            tiles,
             approvalsChannelId: String(formData.get('approvalsChannelId') ?? ''),
             announcementsChannelId: String(
               formData.get('announcementsChannelId') ?? '',
@@ -209,12 +213,17 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const submitting = navigation.state === 'submitting';
+  const [tiles, setTiles] = useState<IBoardTileInput[]>([]);
+  const boardValid =
+    tiles.length > 0 &&
+    tiles.every(tile => tile.type !== 'TASK' || (tile.name ?? '').trim());
 
   return (
-    <Box className="max-w-2xl">
+    <Box>
       <SectionHeading title="New tile race" summary="no race is currently open" />
       <Form method="post" className="mt-4 flex flex-col gap-4">
         <input type="hidden" name="intent" value="create" />
+        <input type="hidden" name="board" value={JSON.stringify(tiles)} />
         <div className={fieldClass}>
           <Label htmlFor="name">Event name</Label>
           <Input id="name" name="name" required maxLength={100} placeholder="Sanguine Tile Race III" />
@@ -256,28 +265,33 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
           </div>
         </Flex>
         <div className={fieldClass}>
-          <Label htmlFor="board">Board</Label>
-          <textarea
-            id="board"
-            name="board"
-            required
-            rows={14}
-            placeholder={BOARD_SCRIPT_PLACEHOLDER}
-            className="rounded-sm border border-gray-700 bg-gray-900 p-2 text-sm text-gray-100 placeholder:text-gray-600"
-          />
+          <Label>
+            Board — {tiles.length} tile{tiles.length === 1 ? '' : 's'}
+          </Label>
           <Text size="1" className="text-gray-500">
-            One tile per line: <span className="text-gray-300">TASK name | description</span>,{' '}
-            <span className="text-sky-400">FWD n</span>,{' '}
-            <span className="text-red-400">BACK n</span>. Lines starting with # are
-            ignored. START and FINISH are added automatically.
+            Click ＋ to add a tile, click a tile to edit it. START and FINISH are
+            added automatically.
           </Text>
+          <TileRaceBoardBuilder tiles={tiles} onChange={setTiles} />
         </div>
         {actionData?.intent === 'create' && actionData.errors && (
           <ActionErrors errors={actionData.errors} />
         )}
-        <Button size="3" type="submit" disabled={submitting} className="w-fit cursor-pointer">
-          {submitting ? 'Creating…' : 'Create race (draft)'}
-        </Button>
+        <Flex align="center" gap="3">
+          <Button
+            size="3"
+            type="submit"
+            disabled={submitting || !boardValid}
+            className="w-fit cursor-pointer"
+          >
+            {submitting ? 'Creating…' : 'Create race (draft)'}
+          </Button>
+          {!boardValid && tiles.length > 0 && (
+            <Text size="2" className="text-gray-500">
+              Every task tile needs a name.
+            </Text>
+          )}
+        </Flex>
       </Form>
     </Box>
   );

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -46,9 +46,9 @@ import { zebraStripeClass } from '~/utils/styles';
 export const meta: MetaFunction = () => [{ title: 'Events Admin — Tile Race' }];
 
 export async function loader({ request }: LoaderFunctionArgs) {
-  const user = await requireStaff(request);
+  await requireStaff(request);
   try {
-    const race = await getAdminRace(user.discordId);
+    const race = await getAdminRace();
     // Channels feed the create form's pickers and name the dashboard's channel refs;
     // a Discord API hiccup degrades to raw ids rather than failing the page.
     const channels = await getGuildTextChannels().catch(
@@ -166,6 +166,17 @@ export async function action({ request }: ActionFunctionArgs) {
   } catch (e) {
     if (e instanceof EventsApiError) {
       return json({ intent, errors: [e.message] }, { status: e.status });
+    }
+    // fetch-level failures (timeout, connection refused) never produce a Response —
+    // surface them inline like API errors instead of crashing to the error boundary
+    if (
+      e instanceof TypeError ||
+      (e instanceof Error && (e.name === 'TimeoutError' || e.name === 'AbortError'))
+    ) {
+      return json(
+        { intent, errors: ['The events API is unreachable — try again shortly.'] },
+        { status: 503 },
+      );
     }
     throw e;
   }

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -13,8 +13,10 @@ import {
   useNavigation,
 } from '@remix-run/react';
 import { useEffect, useMemo, useState } from 'react';
-import { Box, Button, Flex, Select, Table, Text } from '@radix-ui/themes';
+import { Box, Flex, Select, Table, Text } from '@radix-ui/themes';
+import { Button } from '~/components/button';
 import { requireStaff } from '~/services/auth.server';
+import { audit } from '~/services/audit.server';
 import {
   addTeam,
   cancelRace,
@@ -103,6 +105,16 @@ export async function action({ request }: ActionFunctionArgs) {
   const formData = await request.formData();
   const intent = String(formData.get('intent'));
   const teamName = String(formData.get('team') ?? '').trim();
+
+  // Attempts are audited, not just successes — a rejected override is still an
+  // action someone took. The events API logs its own side under the same actor.
+  audit('admin.action', {
+    area: 'tile-race',
+    intent,
+    ...(teamName ? { team: teamName } : {}),
+    discordId: user.discordId,
+    username: user.username,
+  });
 
   try {
     switch (intent) {
@@ -336,10 +348,11 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
         )}
         <Flex align="center" gap="3">
           <Button
-            size="3"
+            variant="primary"
+            size="md"
             type="submit"
             disabled={submitting || !boardValid}
-            className="w-fit cursor-pointer"
+            className="w-fit"
           >
             {submitting ? 'Creating…' : 'Create race (draft)'}
           </Button>
@@ -421,12 +434,7 @@ function RaceDashboard({
         {event.status === 'DRAFT' && (
           <Form method="post" className="mt-3">
             <input type="hidden" name="intent" value="start" />
-            <Button
-              size="2"
-              type="submit"
-              disabled={submitting}
-              className="cursor-pointer"
-            >
+            <Button variant="primary" type="submit" disabled={submitting}>
               Start race — roll first tasks
             </Button>
           </Form>
@@ -487,13 +495,7 @@ function RaceDashboard({
             }}
           >
             <input type="hidden" name="intent" value="end" />
-            <Button
-              size="2"
-              color="amber"
-              variant="soft"
-              type="submit"
-              className="cursor-pointer"
-            >
+            <Button variant="gold" type="submit">
               End race
             </Button>
           </Form>
@@ -509,13 +511,7 @@ function RaceDashboard({
             }}
           >
             <input type="hidden" name="intent" value="cancel" />
-            <Button
-              size="2"
-              color="red"
-              variant="soft"
-              type="submit"
-              className="cursor-pointer"
-            >
+            <Button variant="danger" type="submit">
               Cancel race
             </Button>
           </Form>
@@ -592,26 +588,14 @@ function TeamRow({
                 <fetcher.Form method="post">
                   <input type="hidden" name="intent" value="complete" />
                   <input type="hidden" name="team" value={standing.name} />
-                  <Button
-                    size="2"
-                    variant="soft"
-                    type="submit"
-                    disabled={busy}
-                    className="cursor-pointer"
-                  >
+                  <Button type="submit" disabled={busy}>
                     Complete task
                   </Button>
                 </fetcher.Form>
                 <fetcher.Form method="post">
                   <input type="hidden" name="intent" value="reroll" />
                   <input type="hidden" name="team" value={standing.name} />
-                  <Button
-                    size="2"
-                    variant="soft"
-                    type="submit"
-                    disabled={busy}
-                    className="cursor-pointer"
-                  >
+                  <Button type="submit" disabled={busy}>
                     Reroll
                   </Button>
                 </fetcher.Form>
@@ -627,24 +611,16 @@ function TeamRow({
                     placeholder="tile"
                     className="h-8 w-20 px-2 py-0 text-sm"
                   />
-                  <Button
-                    size="2"
-                    variant="soft"
-                    type="submit"
-                    disabled={busy}
-                    className="cursor-pointer"
-                  >
+                  <Button type="submit" disabled={busy}>
                     Move
                   </Button>
                 </fetcher.Form>
               </>
             )}
             <Button
-              size="2"
-              variant={editing ? 'solid' : 'soft'}
+              variant={editing ? 'primary' : 'default'}
               type="button"
               disabled={busy}
-              className="cursor-pointer"
               onClick={() => setEditing(current => !current)}
             >
               {editing ? 'Close' : 'Edit'}
@@ -660,14 +636,7 @@ function TeamRow({
             >
               <input type="hidden" name="intent" value="removeteam" />
               <input type="hidden" name="team" value={standing.name} />
-              <Button
-                size="2"
-                color="red"
-                variant="soft"
-                type="submit"
-                disabled={busy}
-                className="cursor-pointer"
-              >
+              <Button variant="danger" type="submit" disabled={busy}>
                 Remove
               </Button>
             </fetcher.Form>
@@ -717,10 +686,10 @@ function TeamRow({
                 />
               </div>
               <Button
-                size="2"
+                variant="primary"
                 type="submit"
                 disabled={busy}
-                className="w-fit cursor-pointer"
+                className="w-fit"
               >
                 Save team
               </Button>
@@ -767,10 +736,10 @@ function AddTeamForm({ members }: { members: IPickerMember[] }) {
           <ActionErrors errors={actionData.errors} />
         )}
         <Button
-          size="2"
+          variant="primary"
           type="submit"
           disabled={submitting}
-          className="w-fit cursor-pointer"
+          className="w-fit"
         >
           Add team
         </Button>

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -12,7 +12,7 @@ import {
   useLoaderData,
   useNavigation,
 } from '@remix-run/react';
-import { useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Box, Button, Flex, Select, Table, Text } from '@radix-ui/themes';
 import { requireStaff } from '~/services/auth.server';
 import {
@@ -28,6 +28,7 @@ import {
   rerollTeam,
   startRace,
   endRace,
+  updateTeam,
 } from '~/services/events-admin-service.server';
 import {
   getGuildTextChannels,
@@ -37,6 +38,7 @@ import { getUsersWithNicknames } from '~/services/sanguine-service.server';
 import { IBoardTileInput } from '~/utils/tile-race-board';
 import { Input } from '~/components/input';
 import { Label } from '~/components/label';
+import { IPickerMember, MemberPicker } from '~/components/MemberPicker';
 import { TileRaceBoardBuilder } from '~/components/TileRaceBoardBuilder';
 import { SectionHeading } from '~/components/SectionHeading';
 import { EmptyState } from '~/components/EmptyState';
@@ -44,57 +46,56 @@ import { zebraStripeClass } from '~/utils/styles';
 
 export const meta: MetaFunction = () => [{ title: 'Events Admin — Tile Race' }];
 
+// The clan roster feeding the member typeahead — same source the rest of the
+// site uses for nickname resolution.
+const getRoster = async (): Promise<IPickerMember[]> => {
+  const users = await getUsersWithNicknames();
+  return users
+    .flatMap(user =>
+      user.nickname
+        ? [{ discordId: user.discordId, nickname: user.nickname }]
+        : [],
+    )
+    .sort((a, b) => a.nickname.localeCompare(b.nickname));
+};
+
 export async function loader({ request }: LoaderFunctionArgs) {
   await requireStaff(request);
   try {
     const race = await getAdminRace();
     // Channels feed the create form's pickers and name the dashboard's channel refs;
-    // a Discord API hiccup degrades to raw ids rather than failing the page.
+    // a Discord API hiccup degrades to raw ids rather than failing the page. Same
+    // spirit for the roster: no roster just means the typeahead only takes raw ids.
     const channels = await getGuildTextChannels().catch(
       () => [] as IGuildTextChannel[],
     );
-    return json({ race, channels, apiError: null as string | null });
+    const members = await getRoster().catch(() => [] as IPickerMember[]);
+    return json({ race, channels, members, apiError: null as string | null });
   } catch (e) {
     const message =
       e instanceof EventsApiError ? e.message : 'Events API is unreachable';
     return json({
       race: null as IAdminTileRace | null,
       channels: [] as IGuildTextChannel[],
+      members: [] as IPickerMember[],
       apiError: message,
     });
   }
 }
 
-// Turns the members field (nicknames or raw Discord ids, one per line or
-// comma-separated) into Discord ids via the same roster the rest of the site uses.
-const resolveMemberIds = async (
-  input: string,
-): Promise<{ ids: string[]; unknown: string[] }> => {
-  const tokens = [
-    ...new Set(
-      input
-        .split(/[\n,]/)
-        .map(token => token.trim())
-        .filter(Boolean),
-    ),
-  ];
-  const users = await getUsersWithNicknames();
-  const idByNickname = new Map(
-    users.map(user => [
-      user.nickname?.toLocaleLowerCase() ?? '',
-      user.discordId,
-    ]),
-  );
-  const resolved = tokens.map(token => ({
-    token,
-    id: /^\d{5,25}$/.test(token)
-      ? token
-      : idByNickname.get(token.toLocaleLowerCase()),
-  }));
-  return {
-    ids: [...new Set(resolved.flatMap(r => (r.id ? [r.id] : [])))],
-    unknown: resolved.filter(r => !r.id).map(r => r.token),
-  };
+// The MemberPicker submits its selection as a JSON array of Discord ids.
+const parseMemberIds = (raw: string): string[] | null => {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return Array.isArray(parsed) &&
+      parsed.every(
+        (id): id is string => typeof id === 'string' && /^\d{5,25}$/.test(id),
+      )
+      ? parsed
+      : null;
+  } catch {
+    return null;
+  }
 };
 
 export async function action({ request }: ActionFunctionArgs) {
@@ -139,21 +140,38 @@ export async function action({ request }: ActionFunctionArgs) {
         return json({ intent, errors: null });
       }
       case 'addteam': {
-        const { ids, unknown } = await resolveMemberIds(
-          String(formData.get('members') ?? ''),
-        );
-        if (unknown.length) {
+        const ids = parseMemberIds(String(formData.get('members') ?? ''));
+        if (!ids?.length) {
           return json(
-            {
-              intent,
-              errors: [`Unknown members: ${unknown.join(', ')}`],
-            },
+            { intent, errors: ['Pick at least one member.'] },
             { status: 400 },
           );
         }
         await addTeam(
           String(formData.get('name') ?? '').trim(),
           ids,
+          user.discordId,
+        );
+        return json({ intent, errors: null });
+      }
+      case 'editteam': {
+        const ids = parseMemberIds(String(formData.get('members') ?? ''));
+        const newName = String(formData.get('name') ?? '').trim();
+        if (!ids?.length) {
+          return json(
+            { intent, errors: ['Pick at least one member.'] },
+            { status: 400 },
+          );
+        }
+        if (!newName) {
+          return json(
+            { intent, errors: ['Team name is required.'] },
+            { status: 400 },
+          );
+        }
+        await updateTeam(
+          teamName,
+          { name: newName, memberDiscordIds: ids },
           user.discordId,
         );
         return json({ intent, errors: null });
@@ -206,7 +224,7 @@ export async function action({ request }: ActionFunctionArgs) {
 }
 
 export default function AdminTileRace() {
-  const { race, channels, apiError } = useLoaderData<typeof loader>();
+  const { race, channels, members, apiError } = useLoaderData<typeof loader>();
 
   if (apiError) {
     return (
@@ -220,7 +238,7 @@ export default function AdminTileRace() {
   }
 
   return race ? (
-    <RaceDashboard race={race} channels={channels} />
+    <RaceDashboard race={race} channels={channels} members={members} />
   ) : (
     <CreateRaceForm channels={channels} />
   );
@@ -360,9 +378,11 @@ function ChannelSelect({
 function RaceDashboard({
   race,
   channels,
+  members,
 }: {
   race: IAdminTileRace;
   channels: IGuildTextChannel[];
+  members: IPickerMember[];
 }) {
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
@@ -447,12 +467,13 @@ function RaceDashboard({
                   key={standing.teamId}
                   standing={standing}
                   raceStatus={event.status}
+                  members={members}
                 />
               ))}
             </Table.Body>
           </Table.Root>
         )}
-        <AddTeamForm />
+        <AddTeamForm members={members} />
       </Box>
 
       <Box>
@@ -509,119 +530,209 @@ function RaceDashboard({
 function TeamRow({
   standing,
   raceStatus,
+  members,
 }: {
   standing: IAdminTileRace['standings'][number];
   raceStatus: IAdminTileRace['event']['status'];
+  members: IPickerMember[];
 }) {
   const fetcher = useFetcher<typeof action>();
   const busy = fetcher.state !== 'idle';
   const raceRunning = raceStatus === 'ACTIVE';
+  const [editing, setEditing] = useState(false);
+
+  const nicknameById = useMemo(
+    () => new Map(members.map(m => [m.discordId, m.nickname])),
+    [members],
+  );
+  const rosterNames = standing.memberDiscordIds
+    .map(id => nicknameById.get(id) ?? id)
+    .join(', ');
+
+  // Close the editor once its save lands cleanly
+  useEffect(() => {
+    if (fetcher.state === 'idle' && fetcher.data && !fetcher.data.errors) {
+      setEditing(false);
+    }
+  }, [fetcher.state, fetcher.data]);
 
   return (
-    <Table.Row className={zebraStripeClass}>
-      <Table.Cell>
-        <Text size="3" className="text-gray-100">
-          {standing.name}
-        </Text>
-      </Table.Cell>
-      <Table.Cell justify="end">
-        <span className="whitespace-nowrap">
+    <>
+      <Table.Row className={zebraStripeClass}>
+        <Table.Cell>
           <Text size="3" className="text-gray-100">
-            {standing.tileIndex}
+            {standing.name}
           </Text>
-          <Text size="2" className="text-gray-600">
-            {' '}
-            / {standing.finishIndex}
-          </Text>
-        </span>
-      </Table.Cell>
-      <Table.Cell className="hidden md:table-cell">
-        <Text size="3" className="text-gray-400">
-          {standing.isFinished ? '🏁 Finished' : standing.currentTask ?? '—'}
-        </Text>
-      </Table.Cell>
-      <Table.Cell>
-        <Flex gap="2" align="center" wrap="wrap">
-          {raceRunning && !standing.isFinished && (
-            <>
-              <fetcher.Form method="post">
-                <input type="hidden" name="intent" value="complete" />
-                <input type="hidden" name="team" value={standing.name} />
-                <Button
-                  size="2"
-                  variant="soft"
-                  type="submit"
-                  disabled={busy}
-                  className="cursor-pointer"
-                >
-                  Complete task
-                </Button>
-              </fetcher.Form>
-              <fetcher.Form method="post">
-                <input type="hidden" name="intent" value="reroll" />
-                <input type="hidden" name="team" value={standing.name} />
-                <Button
-                  size="2"
-                  variant="soft"
-                  type="submit"
-                  disabled={busy}
-                  className="cursor-pointer"
-                >
-                  Reroll
-                </Button>
-              </fetcher.Form>
-              <fetcher.Form method="post" className="flex items-center gap-1">
-                <input type="hidden" name="intent" value="move" />
-                <input type="hidden" name="team" value={standing.name} />
-                <Input
-                  name="tile"
-                  type="number"
-                  min={1}
-                  max={standing.finishIndex}
-                  required
-                  placeholder="tile"
-                  className="h-8 w-20 px-2 py-0 text-sm"
-                />
-                <Button
-                  size="2"
-                  variant="soft"
-                  type="submit"
-                  disabled={busy}
-                  className="cursor-pointer"
-                >
-                  Move
-                </Button>
-              </fetcher.Form>
-            </>
+          {rosterNames && (
+            <Text as="p" size="2" className="text-sanguine-bright">
+              {rosterNames}
+            </Text>
           )}
-          <fetcher.Form
-            method="post"
-            onSubmit={e => {
-              if (!confirm(`Remove ${standing.name} and all of its progress?`))
-                e.preventDefault();
-            }}
-          >
-            <input type="hidden" name="intent" value="removeteam" />
-            <input type="hidden" name="team" value={standing.name} />
+        </Table.Cell>
+        <Table.Cell justify="end">
+          <span className="whitespace-nowrap">
+            <Text size="3" className="text-gray-100">
+              {standing.tileIndex}
+            </Text>
+            <Text size="2" className="text-gray-600">
+              {' '}
+              / {standing.finishIndex}
+            </Text>
+          </span>
+        </Table.Cell>
+        <Table.Cell className="hidden md:table-cell">
+          <Text size="3" className="text-gray-400">
+            {standing.isFinished ? '🏁 Finished' : standing.currentTask ?? '—'}
+          </Text>
+        </Table.Cell>
+        <Table.Cell>
+          <Flex gap="2" align="center" wrap="wrap">
+            {raceRunning && !standing.isFinished && (
+              <>
+                <fetcher.Form method="post">
+                  <input type="hidden" name="intent" value="complete" />
+                  <input type="hidden" name="team" value={standing.name} />
+                  <Button
+                    size="2"
+                    variant="soft"
+                    type="submit"
+                    disabled={busy}
+                    className="cursor-pointer"
+                  >
+                    Complete task
+                  </Button>
+                </fetcher.Form>
+                <fetcher.Form method="post">
+                  <input type="hidden" name="intent" value="reroll" />
+                  <input type="hidden" name="team" value={standing.name} />
+                  <Button
+                    size="2"
+                    variant="soft"
+                    type="submit"
+                    disabled={busy}
+                    className="cursor-pointer"
+                  >
+                    Reroll
+                  </Button>
+                </fetcher.Form>
+                <fetcher.Form method="post" className="flex items-center gap-1">
+                  <input type="hidden" name="intent" value="move" />
+                  <input type="hidden" name="team" value={standing.name} />
+                  <Input
+                    name="tile"
+                    type="number"
+                    min={1}
+                    max={standing.finishIndex}
+                    required
+                    placeholder="tile"
+                    className="h-8 w-20 px-2 py-0 text-sm"
+                  />
+                  <Button
+                    size="2"
+                    variant="soft"
+                    type="submit"
+                    disabled={busy}
+                    className="cursor-pointer"
+                  >
+                    Move
+                  </Button>
+                </fetcher.Form>
+              </>
+            )}
             <Button
               size="2"
-              color="red"
-              variant="soft"
-              type="submit"
+              variant={editing ? 'solid' : 'soft'}
+              type="button"
               disabled={busy}
               className="cursor-pointer"
+              onClick={() => setEditing(current => !current)}
             >
-              Remove
+              {editing ? 'Close' : 'Edit'}
             </Button>
-          </fetcher.Form>
-        </Flex>
-        {fetcher.data?.errors && <ActionErrors errors={fetcher.data.errors} />}
-      </Table.Cell>
-    </Table.Row>
+            <fetcher.Form
+              method="post"
+              onSubmit={e => {
+                if (
+                  !confirm(`Remove ${standing.name} and all of its progress?`)
+                )
+                  e.preventDefault();
+              }}
+            >
+              <input type="hidden" name="intent" value="removeteam" />
+              <input type="hidden" name="team" value={standing.name} />
+              <Button
+                size="2"
+                color="red"
+                variant="soft"
+                type="submit"
+                disabled={busy}
+                className="cursor-pointer"
+              >
+                Remove
+              </Button>
+            </fetcher.Form>
+          </Flex>
+          {fetcher.data?.errors && (
+            <ActionErrors errors={fetcher.data.errors} />
+          )}
+        </Table.Cell>
+      </Table.Row>
+      {editing && (
+        <Table.Row>
+          <Table.Cell colSpan={4} className="bg-sanguine-red/[0.04]">
+            <fetcher.Form
+              method="post"
+              className="flex max-w-xl flex-col gap-3 py-2"
+            >
+              <input type="hidden" name="intent" value="editteam" />
+              <input type="hidden" name="team" value={standing.name} />
+              <div className={fieldClass}>
+                <Label
+                  className="text-base"
+                  htmlFor={`editName-${standing.teamId}`}
+                >
+                  Team name
+                </Label>
+                <Input
+                  id={`editName-${standing.teamId}`}
+                  name="name"
+                  required
+                  maxLength={50}
+                  defaultValue={standing.name}
+                  className="text-base"
+                />
+              </div>
+              <div className={fieldClass}>
+                <Label
+                  className="text-base"
+                  htmlFor={`editMembers-${standing.teamId}`}
+                >
+                  Members
+                </Label>
+                <MemberPicker
+                  id={`editMembers-${standing.teamId}`}
+                  members={members}
+                  inputName="members"
+                  defaultSelectedIds={standing.memberDiscordIds}
+                />
+              </div>
+              <Button
+                size="2"
+                type="submit"
+                disabled={busy}
+                className="w-fit cursor-pointer"
+              >
+                Save team
+              </Button>
+            </fetcher.Form>
+          </Table.Cell>
+        </Table.Row>
+      )}
+    </>
   );
 }
 
-function AddTeamForm() {
+function AddTeamForm({ members }: { members: IPickerMember[] }) {
   const actionData = useActionData<typeof action>();
   const navigation = useNavigation();
   const submitting = navigation.state === 'submitting';
@@ -648,15 +759,9 @@ function AddTeamForm() {
         </div>
         <div className={fieldClass}>
           <Label className="text-base" htmlFor="members">
-            Members — OSRS names or Discord ids, one per line
+            Members
           </Label>
-          <textarea
-            id="members"
-            name="members"
-            required
-            rows={4}
-            className="rounded-sm border border-gray-700 bg-gray-900 p-2 text-base text-gray-100 placeholder:text-gray-600"
-          />
+          <MemberPicker id="members" members={members} inputName="members" />
         </div>
         {actionData?.intent === 'addteam' && actionData.errors && (
           <ActionErrors errors={actionData.errors} />

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -1,0 +1,549 @@
+import {
+  ActionFunctionArgs,
+  json,
+  LoaderFunctionArgs,
+  MetaFunction,
+} from '@remix-run/node';
+import {
+  Form,
+  Link,
+  useActionData,
+  useFetcher,
+  useLoaderData,
+  useNavigation,
+} from '@remix-run/react';
+import { Box, Button, Flex, Select, Table, Text } from '@radix-ui/themes';
+import { requireStaff } from '~/services/auth.server';
+import {
+  addTeam,
+  cancelRace,
+  completeTeamTask,
+  createRace,
+  EventsApiError,
+  getAdminRace,
+  IAdminTileRace,
+  moveTeam,
+  removeTeam,
+  rerollTeam,
+  startRace,
+  endRace,
+} from '~/services/events-admin-service.server';
+import {
+  getGuildTextChannels,
+  IGuildTextChannel,
+} from '~/services/discord-admin-service.server';
+import { getUsersWithNicknames } from '~/services/sanguine-service.server';
+import {
+  BOARD_SCRIPT_PLACEHOLDER,
+  parseBoardScript,
+} from '~/utils/tile-race-board';
+import { Input } from '~/components/input';
+import { Label } from '~/components/label';
+import { SectionHeading } from '~/components/SectionHeading';
+import { EmptyState } from '~/components/EmptyState';
+import { zebraStripeClass } from '~/utils/styles';
+
+export const meta: MetaFunction = () => [{ title: 'Events Admin — Tile Race' }];
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await requireStaff(request);
+  try {
+    const race = await getAdminRace(user.discordId);
+    // Channels feed the create form's pickers and name the dashboard's channel refs;
+    // a Discord API hiccup degrades to raw ids rather than failing the page.
+    const channels = await getGuildTextChannels().catch(
+      () => [] as IGuildTextChannel[],
+    );
+    return json({ race, channels, apiError: null as string | null });
+  } catch (e) {
+    const message =
+      e instanceof EventsApiError ? e.message : 'Events API is unreachable';
+    return json({
+      race: null as IAdminTileRace | null,
+      channels: [] as IGuildTextChannel[],
+      apiError: message,
+    });
+  }
+}
+
+// Turns the members field (nicknames or raw Discord ids, one per line or
+// comma-separated) into Discord ids via the same roster the rest of the site uses.
+const resolveMemberIds = async (
+  input: string,
+): Promise<{ ids: string[]; unknown: string[] }> => {
+  const tokens = [
+    ...new Set(
+      input
+        .split(/[\n,]/)
+        .map(token => token.trim())
+        .filter(Boolean),
+    ),
+  ];
+  const users = await getUsersWithNicknames();
+  const idByNickname = new Map(
+    users.map(user => [user.nickname?.toLocaleLowerCase() ?? '', user.discordId]),
+  );
+  const resolved = tokens.map(token => ({
+    token,
+    id: /^\d{5,25}$/.test(token)
+      ? token
+      : idByNickname.get(token.toLocaleLowerCase()),
+  }));
+  return {
+    ids: [...new Set(resolved.flatMap(r => (r.id ? [r.id] : [])))],
+    unknown: resolved.filter(r => !r.id).map(r => r.token),
+  };
+};
+
+export async function action({ request }: ActionFunctionArgs) {
+  const user = await requireStaff(request);
+  const formData = await request.formData();
+  const intent = String(formData.get('intent'));
+  const teamName = String(formData.get('team') ?? '').trim();
+
+  try {
+    switch (intent) {
+      case 'create': {
+        const board = parseBoardScript(String(formData.get('board') ?? ''));
+        if (!board.ok) {
+          return json({ intent, errors: board.errors }, { status: 400 });
+        }
+        await createRace(
+          {
+            name: String(formData.get('name') ?? '').trim(),
+            diceSides: Number(formData.get('diceSides') ?? 6),
+            tiles: board.tiles,
+            approvalsChannelId: String(formData.get('approvalsChannelId') ?? ''),
+            announcementsChannelId: String(
+              formData.get('announcementsChannelId') ?? '',
+            ),
+            days: Number(formData.get('days') ?? 14),
+          },
+          user.discordId,
+        );
+        return json({ intent, errors: null });
+      }
+      case 'addteam': {
+        const { ids, unknown } = await resolveMemberIds(
+          String(formData.get('members') ?? ''),
+        );
+        if (unknown.length) {
+          return json(
+            {
+              intent,
+              errors: [`Unknown members: ${unknown.join(', ')}`],
+            },
+            { status: 400 },
+          );
+        }
+        await addTeam(String(formData.get('name') ?? '').trim(), ids, user.discordId);
+        return json({ intent, errors: null });
+      }
+      case 'removeteam':
+        await removeTeam(teamName, user.discordId);
+        return json({ intent, errors: null });
+      case 'start':
+        await startRace(user.discordId);
+        return json({ intent, errors: null });
+      case 'move':
+        await moveTeam(teamName, Number(formData.get('tile')), user.discordId);
+        return json({ intent, errors: null });
+      case 'complete':
+        await completeTeamTask(teamName, user.discordId);
+        return json({ intent, errors: null });
+      case 'reroll':
+        await rerollTeam(teamName, user.discordId);
+        return json({ intent, errors: null });
+      case 'end':
+        await endRace(user.discordId);
+        return json({ intent, errors: null });
+      case 'cancel':
+        await cancelRace(user.discordId);
+        return json({ intent, errors: null });
+      default:
+        return json({ intent, errors: ['Unknown action'] }, { status: 400 });
+    }
+  } catch (e) {
+    if (e instanceof EventsApiError) {
+      return json({ intent, errors: [e.message] }, { status: e.status });
+    }
+    throw e;
+  }
+}
+
+export default function AdminTileRace() {
+  const { race, channels, apiError } = useLoaderData<typeof loader>();
+
+  if (apiError) {
+    return (
+      <Box>
+        <SectionHeading title="Tile race" />
+        <Text as="p" size="3" className="mt-4 text-red-400">
+          {apiError}. Is the events API running?
+        </Text>
+      </Box>
+    );
+  }
+
+  return race ? (
+    <RaceDashboard race={race} channels={channels} />
+  ) : (
+    <CreateRaceForm channels={channels} />
+  );
+}
+
+const fieldClass = 'flex flex-col gap-1.5';
+
+function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
+  const actionData = useActionData<typeof action>();
+  const navigation = useNavigation();
+  const submitting = navigation.state === 'submitting';
+
+  return (
+    <Box className="max-w-2xl">
+      <SectionHeading title="New tile race" summary="no race is currently open" />
+      <Form method="post" className="mt-4 flex flex-col gap-4">
+        <input type="hidden" name="intent" value="create" />
+        <div className={fieldClass}>
+          <Label htmlFor="name">Event name</Label>
+          <Input id="name" name="name" required maxLength={100} placeholder="Sanguine Tile Race III" />
+        </div>
+        <Flex gap="4" wrap="wrap">
+          <div className={fieldClass}>
+            <Label htmlFor="diceSides">Dice sides</Label>
+            <Input
+              id="diceSides"
+              name="diceSides"
+              type="number"
+              min={2}
+              max={20}
+              defaultValue={6}
+              className="w-24"
+            />
+          </div>
+          <div className={fieldClass}>
+            <Label htmlFor="days">Planned days</Label>
+            <Input
+              id="days"
+              name="days"
+              type="number"
+              min={1}
+              max={90}
+              defaultValue={14}
+              className="w-24"
+            />
+          </div>
+        </Flex>
+        <Flex gap="4" wrap="wrap">
+          <div className={fieldClass}>
+            <Label htmlFor="approvalsChannelId">Approvals channel (private)</Label>
+            <ChannelSelect name="approvalsChannelId" channels={channels} />
+          </div>
+          <div className={fieldClass}>
+            <Label htmlFor="announcementsChannelId">Announcements channel (public)</Label>
+            <ChannelSelect name="announcementsChannelId" channels={channels} />
+          </div>
+        </Flex>
+        <div className={fieldClass}>
+          <Label htmlFor="board">Board</Label>
+          <textarea
+            id="board"
+            name="board"
+            required
+            rows={14}
+            placeholder={BOARD_SCRIPT_PLACEHOLDER}
+            className="rounded-sm border border-gray-700 bg-gray-900 p-2 text-sm text-gray-100 placeholder:text-gray-600"
+          />
+          <Text size="1" className="text-gray-500">
+            One tile per line: <span className="text-gray-300">TASK name | description</span>,{' '}
+            <span className="text-sky-400">FWD n</span>,{' '}
+            <span className="text-red-400">BACK n</span>. Lines starting with # are
+            ignored. START and FINISH are added automatically.
+          </Text>
+        </div>
+        {actionData?.intent === 'create' && actionData.errors && (
+          <ActionErrors errors={actionData.errors} />
+        )}
+        <Button size="3" type="submit" disabled={submitting} className="w-fit cursor-pointer">
+          {submitting ? 'Creating…' : 'Create race (draft)'}
+        </Button>
+      </Form>
+    </Box>
+  );
+}
+
+function ChannelSelect({
+  name,
+  channels,
+}: {
+  name: string;
+  channels: IGuildTextChannel[];
+}) {
+  return (
+    <Select.Root name={name} required>
+      <Select.Trigger placeholder="Pick a channel" className="min-w-56" />
+      <Select.Content>
+        {channels.map(channel => (
+          <Select.Item key={channel.id} value={channel.id}>
+            #{channel.name}
+          </Select.Item>
+        ))}
+      </Select.Content>
+    </Select.Root>
+  );
+}
+
+function RaceDashboard({
+  race,
+  channels,
+}: {
+  race: IAdminTileRace;
+  channels: IGuildTextChannel[];
+}) {
+  const actionData = useActionData<typeof action>();
+  const navigation = useNavigation();
+  const submitting = navigation.state === 'submitting';
+  const { event, board, standings } = race;
+  const finished = standings.filter(s => s.isFinished).length;
+  const channelName = (id: string) =>
+    `#${channels.find(channel => channel.id === id)?.name ?? id}`;
+
+  return (
+    <Flex direction="column" gap="6">
+      <Box>
+        <SectionHeading
+          title={event.name}
+          summary={`${event.status} · ${finished} of ${standings.length} finished`}
+        />
+        <Text as="p" size="3" className="mt-2 text-gray-400">
+          <span className="text-gray-100">{board.tileCount}</span> tiles, d
+          <span className="text-gray-100">{board.diceSides}</span>. Approvals in{' '}
+          <span className="text-gray-100">
+            {channelName(race.channels.approvalsChannelId)}
+          </span>
+          , announcements in{' '}
+          <span className="text-gray-100">
+            {channelName(race.channels.announcementsChannelId)}
+          </span>
+          .
+          The public page is{' '}
+          <Link to="/tile-race" className="text-sanguine-bright hover:text-white">
+            /tile-race
+          </Link>
+          .
+        </Text>
+        {event.status === 'DRAFT' && (
+          <Form method="post" className="mt-3">
+            <input type="hidden" name="intent" value="start" />
+            <Button size="2" type="submit" disabled={submitting} className="cursor-pointer">
+              Start race — roll first tasks
+            </Button>
+          </Form>
+        )}
+        {actionData?.intent === 'start' && actionData.errors && (
+          <ActionErrors errors={actionData.errors} />
+        )}
+      </Box>
+
+      <Box>
+        <SectionHeading title="Teams" summary={`${standings.length} teams`} />
+        {standings.length === 0 ? (
+          <EmptyState>No teams yet — add the first one below.</EmptyState>
+        ) : (
+          <Table.Root size="2" mt="2">
+            <Table.Header>
+              <Table.Row>
+                <Table.ColumnHeaderCell className="text-osrs-orange">Team</Table.ColumnHeaderCell>
+                <Table.ColumnHeaderCell justify="end" className="text-osrs-orange">Tile</Table.ColumnHeaderCell>
+                <Table.ColumnHeaderCell className="hidden text-osrs-orange md:table-cell">
+                  Current task
+                </Table.ColumnHeaderCell>
+                <Table.ColumnHeaderCell className="text-osrs-orange">Overrides</Table.ColumnHeaderCell>
+              </Table.Row>
+            </Table.Header>
+            <Table.Body>
+              {standings.map(standing => (
+                <TeamRow
+                  key={standing.teamId}
+                  standing={standing}
+                  raceStatus={event.status}
+                />
+              ))}
+            </Table.Body>
+          </Table.Root>
+        )}
+        <AddTeamForm />
+      </Box>
+
+      <Box>
+        <SectionHeading title="Danger zone" />
+        <Flex gap="3" mt="3">
+          <Form
+            method="post"
+            onSubmit={e => {
+              if (!confirm('End the race and post final standings?')) e.preventDefault();
+            }}
+          >
+            <input type="hidden" name="intent" value="end" />
+            <Button size="2" color="amber" variant="soft" type="submit" className="cursor-pointer">
+              End race
+            </Button>
+          </Form>
+          <Form
+            method="post"
+            onSubmit={e => {
+              if (!confirm('Cancel the race? Progress stays in the database but the race is over.'))
+                e.preventDefault();
+            }}
+          >
+            <input type="hidden" name="intent" value="cancel" />
+            <Button size="2" color="red" variant="soft" type="submit" className="cursor-pointer">
+              Cancel race
+            </Button>
+          </Form>
+        </Flex>
+        {(actionData?.intent === 'end' || actionData?.intent === 'cancel') &&
+          actionData.errors && <ActionErrors errors={actionData.errors} />}
+      </Box>
+    </Flex>
+  );
+}
+
+function TeamRow({
+  standing,
+  raceStatus,
+}: {
+  standing: IAdminTileRace['standings'][number];
+  raceStatus: IAdminTileRace['event']['status'];
+}) {
+  const fetcher = useFetcher<typeof action>();
+  const busy = fetcher.state !== 'idle';
+  const raceRunning = raceStatus === 'ACTIVE';
+
+  return (
+    <Table.Row className={zebraStripeClass}>
+      <Table.Cell>
+        <Text size="2" className="text-gray-100">
+          {standing.name}
+        </Text>
+      </Table.Cell>
+      <Table.Cell justify="end">
+        <span className="whitespace-nowrap">
+          <Text size="2" className="text-gray-100">
+            {standing.tileIndex}
+          </Text>
+          <Text size="1" className="text-gray-600">
+            {' '}
+            / {standing.finishIndex}
+          </Text>
+        </span>
+      </Table.Cell>
+      <Table.Cell className="hidden md:table-cell">
+        <Text size="2" className="text-gray-400">
+          {standing.isFinished ? '🏁 Finished' : (standing.currentTask ?? '—')}
+        </Text>
+      </Table.Cell>
+      <Table.Cell>
+        <Flex gap="2" align="center" wrap="wrap">
+          {raceRunning && !standing.isFinished && (
+            <>
+              <fetcher.Form method="post">
+                <input type="hidden" name="intent" value="complete" />
+                <input type="hidden" name="team" value={standing.name} />
+                <Button size="1" variant="soft" type="submit" disabled={busy} className="cursor-pointer">
+                  Complete task
+                </Button>
+              </fetcher.Form>
+              <fetcher.Form method="post">
+                <input type="hidden" name="intent" value="reroll" />
+                <input type="hidden" name="team" value={standing.name} />
+                <Button size="1" variant="soft" type="submit" disabled={busy} className="cursor-pointer">
+                  Reroll
+                </Button>
+              </fetcher.Form>
+              <fetcher.Form method="post" className="flex items-center gap-1">
+                <input type="hidden" name="intent" value="move" />
+                <input type="hidden" name="team" value={standing.name} />
+                <Input
+                  name="tile"
+                  type="number"
+                  min={1}
+                  max={standing.finishIndex}
+                  required
+                  placeholder="tile"
+                  className="h-6 w-16 px-1 py-0 text-xs"
+                />
+                <Button size="1" variant="soft" type="submit" disabled={busy} className="cursor-pointer">
+                  Move
+                </Button>
+              </fetcher.Form>
+            </>
+          )}
+          <fetcher.Form
+            method="post"
+            onSubmit={e => {
+              if (!confirm(`Remove ${standing.name} and all of its progress?`))
+                e.preventDefault();
+            }}
+          >
+            <input type="hidden" name="intent" value="removeteam" />
+            <input type="hidden" name="team" value={standing.name} />
+            <Button size="1" color="red" variant="soft" type="submit" disabled={busy} className="cursor-pointer">
+              Remove
+            </Button>
+          </fetcher.Form>
+        </Flex>
+        {fetcher.data?.errors && <ActionErrors errors={fetcher.data.errors} />}
+      </Table.Cell>
+    </Table.Row>
+  );
+}
+
+function AddTeamForm() {
+  const actionData = useActionData<typeof action>();
+  const navigation = useNavigation();
+  const submitting = navigation.state === 'submitting';
+
+  return (
+    <Box mt="4" className="max-w-xl">
+      <Text as="p" size="3" className="text-osrs-orange">
+        Add a team
+      </Text>
+      <Form method="post" className="mt-2 flex flex-col gap-3">
+        <input type="hidden" name="intent" value="addteam" />
+        <div className={fieldClass}>
+          <Label htmlFor="teamName">Team name</Label>
+          <Input id="teamName" name="name" required maxLength={50} placeholder="Blood Reapers" />
+        </div>
+        <div className={fieldClass}>
+          <Label htmlFor="members">Members — OSRS names or Discord ids, one per line</Label>
+          <textarea
+            id="members"
+            name="members"
+            required
+            rows={4}
+            className="rounded-sm border border-gray-700 bg-gray-900 p-2 text-sm text-gray-100 placeholder:text-gray-600"
+          />
+        </div>
+        {actionData?.intent === 'addteam' && actionData.errors && (
+          <ActionErrors errors={actionData.errors} />
+        )}
+        <Button size="2" type="submit" disabled={submitting} className="w-fit cursor-pointer">
+          Add team
+        </Button>
+      </Form>
+    </Box>
+  );
+}
+
+function ActionErrors({ errors }: { errors: string[] }) {
+  return (
+    <Box mt="2">
+      {errors.map(error => (
+        <Text key={error} as="p" size="2" className="text-red-400">
+          {error}
+        </Text>
+      ))}
+    </Box>
+  );
+}

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -1,5 +1,5 @@
 import { json, LoaderFunctionArgs } from '@remix-run/node';
-import { Form, Outlet, useLoaderData } from '@remix-run/react';
+import { Form, Link, Outlet, useLoaderData } from '@remix-run/react';
 import { Box, Button, Container, Flex, Text } from '@radix-ui/themes';
 import { requireStaff } from '~/services/auth.server';
 
@@ -22,9 +22,11 @@ export default function AdminLayout() {
         gap="3"
         className="mb-6 border-b-2 border-b-sanguine-red pb-2"
       >
-        <Text size="3" className="text-osrs-orange">
-          Events admin
-        </Text>
+        <Link to="/admin">
+          <Text size="3" className="text-osrs-orange hover:text-white">
+            Events admin
+          </Text>
+        </Link>
         <Flex align="center" gap="3">
           {user.avatarUrl && (
             <img

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -1,6 +1,7 @@
 import { json, LoaderFunctionArgs } from '@remix-run/node';
 import { Form, Link, Outlet, useLoaderData } from '@remix-run/react';
-import { Box, Button, Container, Flex, Text } from '@radix-ui/themes';
+import { Box, Container, Flex, Text } from '@radix-ui/themes';
+import { Button } from '~/components/button';
 import { requireStaff } from '~/services/auth.server';
 
 // Layout gate for every /admin screen: requireStaff redirects anonymous visitors
@@ -41,14 +42,7 @@ export default function AdminLayout() {
             {user.username}
           </Text>
           <Form method="post" action="/logout">
-            <Button
-              size="2"
-              variant="soft"
-              type="submit"
-              className="cursor-pointer"
-            >
-              Log out
-            </Button>
+            <Button type="submit">Log out</Button>
           </Form>
         </Flex>
       </Flex>

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -35,11 +35,16 @@ export default function AdminLayout() {
               className="rounded-sm"
             />
           )}
-          <Text size="2" className="text-sanguine-bright">
+          <Text size="3" className="text-sanguine-bright">
             {user.username}
           </Text>
           <Form method="post" action="/logout">
-            <Button size="1" variant="soft" type="submit" className="cursor-pointer">
+            <Button
+              size="2"
+              variant="soft"
+              type="submit"
+              className="cursor-pointer"
+            >
               Log out
             </Button>
           </Form>

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -1,0 +1,53 @@
+import { json, LoaderFunctionArgs } from '@remix-run/node';
+import { Form, Outlet, useLoaderData } from '@remix-run/react';
+import { Box, Button, Container, Flex, Text } from '@radix-ui/themes';
+import { requireStaff } from '~/services/auth.server';
+
+// Layout gate for every /admin screen: requireStaff redirects anonymous visitors
+// to /login and non-staff to /login?denied=1. Child routes re-check in their own
+// loaders/actions — layout loaders don't guard child actions.
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await requireStaff(request);
+  return json({ user });
+}
+
+export default function AdminLayout() {
+  const { user } = useLoaderData<typeof loader>();
+
+  return (
+    <Container size="4" mt="3" pb="6" px="4">
+      <Flex
+        align="center"
+        justify="between"
+        gap="3"
+        className="mb-6 border-b-2 border-b-sanguine-red pb-2"
+      >
+        <Text size="3" className="text-osrs-orange">
+          Events admin
+        </Text>
+        <Flex align="center" gap="3">
+          {user.avatarUrl && (
+            <img
+              src={user.avatarUrl}
+              alt=""
+              width={24}
+              height={24}
+              className="rounded-sm"
+            />
+          )}
+          <Text size="2" className="text-sanguine-bright">
+            {user.username}
+          </Text>
+          <Form method="post" action="/logout">
+            <Button size="1" variant="soft" type="submit" className="cursor-pointer">
+              Log out
+            </Button>
+          </Form>
+        </Flex>
+      </Flex>
+      <Box>
+        <Outlet />
+      </Box>
+    </Container>
+  );
+}

--- a/app/routes/auth.discord.callback.tsx
+++ b/app/routes/auth.discord.callback.tsx
@@ -1,0 +1,8 @@
+import { LoaderFunctionArgs } from '@remix-run/node';
+import { authenticator } from '~/services/auth.server';
+
+export const loader = ({ request }: LoaderFunctionArgs) =>
+  authenticator.authenticate('discord', request, {
+    successRedirect: '/admin',
+    failureRedirect: '/login',
+  });

--- a/app/routes/auth.discord.tsx
+++ b/app/routes/auth.discord.tsx
@@ -1,0 +1,7 @@
+import { ActionFunctionArgs, redirect } from '@remix-run/node';
+import { authenticator } from '~/services/auth.server';
+
+export const loader = () => redirect('/login');
+
+export const action = ({ request }: ActionFunctionArgs) =>
+  authenticator.authenticate('discord', request);

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,6 +1,7 @@
 import { json, LoaderFunctionArgs, MetaFunction, redirect } from '@remix-run/node';
 import { Form, useLoaderData } from '@remix-run/react';
-import { Button, Container, Text } from '@radix-ui/themes';
+import { Container, Text } from '@radix-ui/themes';
+import { Button } from '~/components/button';
 import {
   authenticator,
   getSessionUser,
@@ -49,7 +50,7 @@ export default function Login() {
         </Text>
       )}
       <Form method="post" action="/auth/discord">
-        <Button size="3" type="submit" className="cursor-pointer">
+        <Button variant="primary" size="md" type="submit">
           Sign in with Discord
         </Button>
       </Form>

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,7 +1,11 @@
 import { json, LoaderFunctionArgs, MetaFunction, redirect } from '@remix-run/node';
 import { Form, useLoaderData } from '@remix-run/react';
 import { Button, Container, Text } from '@radix-ui/themes';
-import { getSessionUser } from '~/services/auth.server';
+import {
+  authenticator,
+  getSessionUser,
+  sessionStorage,
+} from '~/services/auth.server';
 import { PageHeader } from '~/components/PageHeader';
 
 export const meta: MetaFunction = () => [{ title: 'Events Admin — Login' }];
@@ -12,11 +16,20 @@ export async function loader({ request }: LoaderFunctionArgs) {
     throw redirect('/admin');
   }
   const denied = new URL(request.url).searchParams.has('denied');
-  return json({ denied });
+  // remix-auth flashes the failure reason into the session on failureRedirect —
+  // surface it instead of silently looping back to the sign-in button.
+  const session = await sessionStorage.getSession(request.headers.get('Cookie'));
+  const flashed = session.get(authenticator.sessionErrorKey) as
+    | { message?: string }
+    | undefined;
+  return json(
+    { denied, authError: flashed?.message ?? null },
+    { headers: { 'Set-Cookie': await sessionStorage.commitSession(session) } },
+  );
 }
 
 export default function Login() {
-  const { denied } = useLoaderData<typeof loader>();
+  const { denied, authError } = useLoaderData<typeof loader>();
 
   return (
     <Container size="2" mt="3" pb="6" px="4">
@@ -28,6 +41,11 @@ export default function Login() {
         <Text as="p" size="3" className="mb-4 text-red-400">
           That account doesn&apos;t hold an event staff role in the Sanguine
           server.
+        </Text>
+      )}
+      {authError && (
+        <Text as="p" size="3" className="mb-4 text-red-400">
+          Discord sign-in failed: {authError}
         </Text>
       )}
       <Form method="post" action="/auth/discord">

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -1,0 +1,40 @@
+import { json, LoaderFunctionArgs, MetaFunction, redirect } from '@remix-run/node';
+import { Form, useLoaderData } from '@remix-run/react';
+import { Button, Container, Text } from '@radix-ui/themes';
+import { getSessionUser } from '~/services/auth.server';
+import { PageHeader } from '~/components/PageHeader';
+
+export const meta: MetaFunction = () => [{ title: 'Events Admin — Login' }];
+
+export async function loader({ request }: LoaderFunctionArgs) {
+  const user = await getSessionUser(request);
+  if (user?.isStaff) {
+    throw redirect('/admin');
+  }
+  const denied = new URL(request.url).searchParams.has('denied');
+  return json({ denied });
+}
+
+export default function Login() {
+  const { denied } = useLoaderData<typeof loader>();
+
+  return (
+    <Container size="2" mt="3" pb="6" px="4">
+      <PageHeader title="Events admin" iconSrc="/sanguine_icon_small.png">
+        Race configuration and overrides for event staff. Sign in with the
+        Discord account that holds your staff role.
+      </PageHeader>
+      {denied && (
+        <Text as="p" size="3" className="mb-4 text-red-400">
+          That account doesn&apos;t hold an event staff role in the Sanguine
+          server.
+        </Text>
+      )}
+      <Form method="post" action="/auth/discord">
+        <Button size="3" type="submit" className="cursor-pointer">
+          Sign in with Discord
+        </Button>
+      </Form>
+    </Container>
+  );
+}

--- a/app/routes/logout.tsx
+++ b/app/routes/logout.tsx
@@ -1,0 +1,7 @@
+import { ActionFunctionArgs, redirect } from '@remix-run/node';
+import { authenticator } from '~/services/auth.server';
+
+export const loader = () => redirect('/');
+
+export const action = ({ request }: ActionFunctionArgs) =>
+  authenticator.logout(request, { redirectTo: '/' });

--- a/app/routes/logout.tsx
+++ b/app/routes/logout.tsx
@@ -1,7 +1,13 @@
 import { ActionFunctionArgs, redirect } from '@remix-run/node';
-import { authenticator } from '~/services/auth.server';
+import { authenticator, getSessionUser } from '~/services/auth.server';
+import { audit } from '~/services/audit.server';
 
 export const loader = () => redirect('/');
 
-export const action = ({ request }: ActionFunctionArgs) =>
-  authenticator.logout(request, { redirectTo: '/' });
+export const action = async ({ request }: ActionFunctionArgs) => {
+  const user = await getSessionUser(request);
+  if (user) {
+    audit('auth.logout', { discordId: user.discordId, username: user.username });
+  }
+  return authenticator.logout(request, { redirectTo: '/' });
+};

--- a/app/routes/tile-race.tsx
+++ b/app/routes/tile-race.tsx
@@ -1,0 +1,335 @@
+import { json, MetaFunction } from '@remix-run/node';
+import { useLoaderData } from '@remix-run/react';
+import { Box, Container, Flex, Table, Text } from '@radix-ui/themes';
+import {
+  getCurrentTileRace,
+  ITileRaceStanding,
+  ITileRaceTile,
+} from '~/services/tile-race-service.server';
+import { getNicknameMapByDiscordIds } from '~/services/sanguine-service.server';
+import { PageHeader } from '~/components/PageHeader';
+import { SectionHeading } from '~/components/SectionHeading';
+import { EmptyState } from '~/components/EmptyState';
+import { zebraStripeClass } from '~/utils/styles';
+
+export const meta: MetaFunction = () => {
+  return [
+    { title: 'Tile Race' },
+    {
+      name: 'description',
+      content:
+        'The Sanguine tile race: teams roll their way across a board of PvM tasks — live positions, current tasks, and the board itself.',
+    },
+  ];
+};
+
+export async function loader() {
+  const race = await getCurrentTileRace().catch(() => null);
+  if (!race) {
+    return json({ race: null, nameByDiscordId: {} as Record<string, string> });
+  }
+  const nameByDiscordId = await getNicknameMapByDiscordIds(
+    race.standings.flatMap(standing => standing.memberDiscordIds),
+  );
+  return json({ race, nameByDiscordId });
+}
+
+// Stable per-team marker colors (never sanguine red — that means members/links).
+const TEAM_COLORS = [
+  '#D9A13C',
+  '#4FB4D8',
+  '#6BBF59',
+  '#A97BD6',
+  '#D66BA0',
+  '#C98A45',
+];
+
+const COLUMNS = 10;
+
+// Chutes-and-ladders reading order: rows alternate direction, and short rows keep
+// their tiles on the side the path travels from (nulls fill the dead cells).
+const buildBoardRows = (tiles: ITileRaceTile[]): (ITileRaceTile | null)[][] =>
+  Array.from({ length: Math.ceil(tiles.length / COLUMNS) }, (_, row) => {
+    const slice = tiles.slice(row * COLUMNS, (row + 1) * COLUMNS);
+    const padded: (ITileRaceTile | null)[] = [
+      ...slice,
+      ...Array<null>(COLUMNS - slice.length).fill(null),
+    ];
+    return row % 2 === 1 ? [...padded].reverse() : padded;
+  });
+
+const tileTitle = (tile: ITileRaceTile): string => {
+  switch (tile.type) {
+    case 'START':
+      return 'Start';
+    case 'FINISH':
+      return 'Finish';
+    case 'GO_BACK':
+      return `Go back ${tile.amount} tiles`;
+    case 'GO_FORWARD':
+      return `Go forward ${tile.amount} tiles`;
+    case 'TASK':
+      return tile.description
+        ? `${tile.name} — ${tile.description}`
+        : (tile.name ?? 'Task');
+  }
+};
+
+function TileCell({
+  tile,
+  teamsHere,
+  colorByTeamId,
+}: {
+  tile: ITileRaceTile | null;
+  teamsHere: ITileRaceStanding[];
+  colorByTeamId: Record<string, string>;
+}) {
+  if (!tile) {
+    return <div aria-hidden />;
+  }
+
+  const content = (() => {
+    switch (tile.type) {
+      case 'START':
+        return <span className="text-[11px] text-green-400">START</span>;
+      case 'FINISH':
+        return <span className="text-[11px] text-green-400">FINISH</span>;
+      case 'GO_BACK':
+        return (
+          <span className="text-[10px] leading-tight text-red-400">
+            Go back {tile.amount}
+          </span>
+        );
+      case 'GO_FORWARD':
+        return (
+          <span className="text-[10px] leading-tight text-sky-400">
+            Forward {tile.amount}
+          </span>
+        );
+      case 'TASK':
+        return (
+          <span className="text-[10px] leading-tight text-gray-200">
+            {tile.name}
+          </span>
+        );
+    }
+  })();
+
+  return (
+    <div
+      title={tileTitle(tile)}
+      className={`relative flex aspect-square flex-col items-center justify-center overflow-hidden rounded-sm border bg-gray-900 p-1 text-center ${
+        teamsHere.length ? 'border-gray-500' : 'border-gray-800'
+      }`}
+    >
+      <span className="absolute left-1 top-0.5 text-[9px] text-gray-600">
+        {tile.index}
+      </span>
+      {content}
+      {teamsHere.length > 0 && (
+        <Flex gap="1" className="absolute bottom-0.5">
+          {teamsHere.map(team => (
+            <span
+              key={team.teamId}
+              title={team.name}
+              className="flex h-3.5 w-3.5 items-center justify-center rounded-sm text-[9px] font-bold text-black"
+              style={{ backgroundColor: colorByTeamId[team.teamId] }}
+            >
+              {team.name.charAt(0)}
+            </span>
+          ))}
+        </Flex>
+      )}
+    </div>
+  );
+}
+
+const statusText = (standing: ITileRaceStanding): string => {
+  if (standing.isFinished) {
+    return `Finished ${ordinal(standing.place ?? 0)}`;
+  }
+  if (standing.moveStatus === 'PENDING_APPROVAL') {
+    return 'Awaiting approval';
+  }
+  if (standing.moveStatus === 'PENDING_SUBMISSION') {
+    return 'On the task';
+  }
+  return 'Waiting to start';
+};
+
+const ordinal = (n: number): string => {
+  const suffix = n === 1 ? 'st' : n === 2 ? 'nd' : n === 3 ? 'rd' : 'th';
+  return `${n}${suffix}`;
+};
+
+export default function TileRace() {
+  const { race, nameByDiscordId } = useLoaderData<typeof loader>();
+
+  if (!race) {
+    return (
+      <Container size="4" mt="3" pb="6" px="4">
+        <PageHeader title="Tile Race" iconSrc="/sanguine_icon_small.png">
+          Teams roll their way across a board of PvM tasks. No race is running
+          right now.
+        </PageHeader>
+        <EmptyState>You roll the dice… nothing interesting happens.</EmptyState>
+      </Container>
+    );
+  }
+
+  const { event, board, standings } = race;
+  const colorByTeamId = Object.fromEntries(
+    [...standings]
+      .sort((a, b) => a.teamId.localeCompare(b.teamId))
+      .map((standing, i) => [
+        standing.teamId,
+        TEAM_COLORS[i % TEAM_COLORS.length],
+      ]),
+  );
+  const rows = buildBoardRows(board.tiles);
+  const teamsByTile = standings.reduce<Record<number, ITileRaceStanding[]>>(
+    (acc, standing) => ({
+      ...acc,
+      [standing.tileIndex]: [...(acc[standing.tileIndex] ?? []), standing],
+    }),
+    {},
+  );
+  const leader = standings.find(s => !s.isFinished);
+  const winner = standings.find(s => s.place === 1);
+
+  return (
+    <Container size="4" mt="3" pb="6" px="4">
+      <PageHeader title={event.name} iconSrc="/sanguine_icon_small.png">
+        <span className="text-gray-100">{standings.length}</span> teams race
+        across <span className="text-gray-100">{board.tileCount}</span> tiles
+        with a d<span className="text-gray-100">{board.diceSides}</span>.{' '}
+        {event.status === 'DRAFT' && 'The race has not started yet.'}
+        {event.status === 'ACTIVE' &&
+          winner &&
+          `${winner.name} has already crossed the line.`}
+        {event.status === 'ACTIVE' &&
+          !winner &&
+          leader &&
+          `${leader.name} leads from tile ${leader.tileIndex}.`}
+        {event.status === 'COMPLETED' &&
+          winner &&
+          `The race is over — ${winner.name} took 1st.`}
+      </PageHeader>
+
+      <Flex direction="column" gap="6">
+        <Box>
+          <SectionHeading
+            title="Standings"
+            summary={`${standings.filter(s => s.isFinished).length} of ${standings.length} finished`}
+          />
+          {standings.length === 0 ? (
+            <EmptyState />
+          ) : (
+            <Table.Root size="2" mt="2">
+              <Table.Header>
+                <Table.Row>
+                  <Table.ColumnHeaderCell className="text-osrs-orange">
+                    Team
+                  </Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell className="hidden text-osrs-orange sm:table-cell">
+                    Members
+                  </Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell justify="end" className="text-osrs-orange">
+                    Tile
+                  </Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell className="hidden text-osrs-orange md:table-cell">
+                    Current task
+                  </Table.ColumnHeaderCell>
+                  <Table.ColumnHeaderCell className="text-osrs-orange">
+                    Status
+                  </Table.ColumnHeaderCell>
+                </Table.Row>
+              </Table.Header>
+              <Table.Body>
+                {standings.map(standing => (
+                  <Table.Row key={standing.teamId} className={zebraStripeClass}>
+                    <Table.Cell>
+                      <Flex align="center" gap="2">
+                        <span
+                          className="h-3 w-3 shrink-0 rounded-sm"
+                          style={{
+                            backgroundColor: colorByTeamId[standing.teamId],
+                          }}
+                        />
+                        <Text size="2" className="text-gray-100">
+                          {standing.name}
+                        </Text>
+                      </Flex>
+                    </Table.Cell>
+                    <Table.Cell className="hidden sm:table-cell">
+                      <Text size="2" className="text-sanguine-bright">
+                        {standing.memberDiscordIds
+                          .map(id => nameByDiscordId[id] ?? 'Unknown')
+                          .join(', ')}
+                      </Text>
+                    </Table.Cell>
+                    <Table.Cell justify="end">
+                      <span className="whitespace-nowrap">
+                        <Text size="2" className="text-gray-100">
+                          {standing.tileIndex}
+                        </Text>
+                        <Text size="1" className="text-gray-600">
+                          {' '}
+                          / {standing.finishIndex}
+                        </Text>
+                      </span>
+                    </Table.Cell>
+                    <Table.Cell className="hidden md:table-cell">
+                      <Text size="2" className="text-gray-400">
+                        {standing.currentTask ?? '—'}
+                      </Text>
+                    </Table.Cell>
+                    <Table.Cell>
+                      <Text
+                        size="2"
+                        className={
+                          standing.place === 1
+                            ? 'text-osrs-gold'
+                            : standing.isFinished
+                              ? 'text-gray-100'
+                              : 'text-gray-400'
+                        }
+                      >
+                        {statusText(standing)}
+                      </Text>
+                    </Table.Cell>
+                  </Table.Row>
+                ))}
+              </Table.Body>
+            </Table.Root>
+          )}
+        </Box>
+
+        <Box>
+          <SectionHeading
+            title="The board"
+            summary={
+              <span>
+                <span className="text-sky-400">forward</span> ·{' '}
+                <span className="text-red-400">back</span> · hover a tile for
+                its full task
+              </span>
+            }
+          />
+          <Box mt="2" className="overflow-x-auto">
+            <div className="grid min-w-[40rem] grid-cols-10 gap-1">
+              {rows.flat().map((tile, i) => (
+                <TileCell
+                  key={tile ? tile.index : `empty-${i}`}
+                  tile={tile}
+                  teamsHere={tile ? (teamsByTile[tile.index] ?? []) : []}
+                  colorByTeamId={colorByTeamId}
+                />
+              ))}
+            </div>
+          </Box>
+        </Box>
+      </Flex>
+    </Container>
+  );
+}

--- a/app/routes/tile-race.tsx
+++ b/app/routes/tile-race.tsx
@@ -13,6 +13,8 @@ import { SectionHeading } from '~/components/SectionHeading';
 import { EmptyState } from '~/components/EmptyState';
 import { zebraStripeClass } from '~/utils/styles';
 import { chunkIntoSnakeRows } from '~/utils/tile-race-board';
+import { getTileImageUrl } from '~/utils/tile-race-images';
+import { TileArt } from '~/components/TileArt';
 
 export const meta: MetaFunction = () => {
   return [
@@ -106,6 +108,11 @@ function TileCell({
     return <div aria-hidden />;
   }
 
+  const imageUrl =
+    tile.type === 'TASK'
+      ? (tile.imageUrl ?? getTileImageUrl(tile.name, tile.description))
+      : null;
+
   const content = (() => {
     switch (tile.type) {
       case 'START':
@@ -140,10 +147,12 @@ function TileCell({
         teamsHere.length ? 'border-gray-500' : 'border-gray-800'
       }`}
     >
+      {imageUrl && <TileArt src={imageUrl} />}
       <span className="absolute left-1 top-0.5 text-[9px] text-gray-600">
         {tile.index}
       </span>
-      {content}
+      {/* relative lifts the label above the absolutely-positioned artwork */}
+      <span className="relative">{content}</span>
       {teamsHere.length > 0 && (
         <Flex gap="1" className="absolute bottom-0.5">
           {teamsHere.map(team => (

--- a/app/routes/tile-race.tsx
+++ b/app/routes/tile-race.tsx
@@ -12,6 +12,7 @@ import { PageHeader } from '~/components/PageHeader';
 import { SectionHeading } from '~/components/SectionHeading';
 import { EmptyState } from '~/components/EmptyState';
 import { zebraStripeClass } from '~/utils/styles';
+import { chunkIntoSnakeRows } from '~/utils/tile-race-board';
 
 export const meta: MetaFunction = () => {
   return [
@@ -74,20 +75,6 @@ const TEAM_COLORS = [
   '#D66BA0',
   '#C98A45',
 ];
-
-const COLUMNS = 10;
-
-// Chutes-and-ladders reading order: rows alternate direction, and short rows keep
-// their tiles on the side the path travels from (nulls fill the dead cells).
-const buildBoardRows = (tiles: ITileRaceTile[]): (ITileRaceTile | null)[][] =>
-  Array.from({ length: Math.ceil(tiles.length / COLUMNS) }, (_, row) => {
-    const slice = tiles.slice(row * COLUMNS, (row + 1) * COLUMNS);
-    const padded: (ITileRaceTile | null)[] = [
-      ...slice,
-      ...Array<null>(COLUMNS - slice.length).fill(null),
-    ];
-    return row % 2 === 1 ? [...padded].reverse() : padded;
-  });
 
 const tileTitle = (tile: ITileRaceTile): string => {
   switch (tile.type) {
@@ -217,7 +204,7 @@ export default function TileRace() {
         TEAM_COLORS[i % TEAM_COLORS.length],
       ]),
   );
-  const rows = buildBoardRows(board.tiles);
+  const rows = chunkIntoSnakeRows(board.tiles);
   const teamsByTile = standings.reduce<Record<number, IStandingView[]>>(
     (acc, standing) => ({
       ...acc,

--- a/app/routes/tile-race.tsx
+++ b/app/routes/tile-race.tsx
@@ -6,6 +6,7 @@ import {
   ITileRaceStanding,
   ITileRaceTile,
 } from '~/services/tile-race-service.server';
+import { getAdminRace } from '~/services/events-admin-service.server';
 import { getNicknameMapByDiscordIds } from '~/services/sanguine-service.server';
 import { PageHeader } from '~/components/PageHeader';
 import { SectionHeading } from '~/components/SectionHeading';
@@ -24,14 +25,44 @@ export const meta: MetaFunction = () => {
 };
 
 export async function loader() {
-  const race = await getCurrentTileRace().catch(() => null);
+  // Prefer the authed admin read — it carries member rosters, which the public API
+  // payload deliberately omits. Rosters resolve to nicknames server-side; raw Discord
+  // ids never reach the browser. Falls back to the public payload (roster-less) so the
+  // page still renders if the service token is missing.
+  const adminRace = await getAdminRace().catch(() => null);
+  const race = adminRace ?? (await getCurrentTileRace().catch(() => null));
   if (!race) {
-    return json({ race: null, nameByDiscordId: {} as Record<string, string> });
+    return json({ race: null });
   }
-  const nameByDiscordId = await getNicknameMapByDiscordIds(
-    race.standings.flatMap(standing => standing.memberDiscordIds),
+  const memberIdsByTeamId = new Map(
+    (adminRace?.standings ?? []).map(s => [s.teamId, s.memberDiscordIds]),
   );
-  return json({ race, nameByDiscordId });
+  const nameByDiscordId = await getNicknameMapByDiscordIds(
+    [...memberIdsByTeamId.values()].flat(),
+  );
+  return json({
+    race: {
+      event: race.event,
+      board: race.board,
+      standings: race.standings.map(standing => ({
+        teamId: standing.teamId,
+        name: standing.name,
+        place: standing.place,
+        tileIndex: standing.tileIndex,
+        finishIndex: standing.finishIndex,
+        currentTask: standing.currentTask,
+        moveStatus: standing.moveStatus,
+        isFinished: standing.isFinished,
+        memberNames: (memberIdsByTeamId.get(standing.teamId) ?? []).map(
+          id => nameByDiscordId[id] ?? 'Unknown',
+        ),
+      })),
+    },
+  });
+}
+
+interface IStandingView extends ITileRaceStanding {
+  memberNames: string[];
 }
 
 // Stable per-team marker colors (never sanguine red — that means members/links).
@@ -81,7 +112,7 @@ function TileCell({
   colorByTeamId,
 }: {
   tile: ITileRaceTile | null;
-  teamsHere: ITileRaceStanding[];
+  teamsHere: IStandingView[];
   colorByTeamId: Record<string, string>;
 }) {
   if (!tile) {
@@ -163,7 +194,7 @@ const ordinal = (n: number): string => {
 };
 
 export default function TileRace() {
-  const { race, nameByDiscordId } = useLoaderData<typeof loader>();
+  const { race } = useLoaderData<typeof loader>();
 
   if (!race) {
     return (
@@ -187,7 +218,7 @@ export default function TileRace() {
       ]),
   );
   const rows = buildBoardRows(board.tiles);
-  const teamsByTile = standings.reduce<Record<number, ITileRaceStanding[]>>(
+  const teamsByTile = standings.reduce<Record<number, IStandingView[]>>(
     (acc, standing) => ({
       ...acc,
       [standing.tileIndex]: [...(acc[standing.tileIndex] ?? []), standing],
@@ -196,6 +227,7 @@ export default function TileRace() {
   );
   const leader = standings.find(s => !s.isFinished);
   const winner = standings.find(s => s.place === 1);
+  const hasRosters = standings.some(s => s.memberNames.length > 0);
 
   return (
     <Container size="4" mt="3" pb="6" px="4">
@@ -231,9 +263,11 @@ export default function TileRace() {
                   <Table.ColumnHeaderCell className="text-osrs-orange">
                     Team
                   </Table.ColumnHeaderCell>
-                  <Table.ColumnHeaderCell className="hidden text-osrs-orange sm:table-cell">
-                    Members
-                  </Table.ColumnHeaderCell>
+                  {hasRosters && (
+                    <Table.ColumnHeaderCell className="hidden text-osrs-orange sm:table-cell">
+                      Members
+                    </Table.ColumnHeaderCell>
+                  )}
                   <Table.ColumnHeaderCell justify="end" className="text-osrs-orange">
                     Tile
                   </Table.ColumnHeaderCell>
@@ -261,13 +295,13 @@ export default function TileRace() {
                         </Text>
                       </Flex>
                     </Table.Cell>
-                    <Table.Cell className="hidden sm:table-cell">
-                      <Text size="2" className="text-sanguine-bright">
-                        {standing.memberDiscordIds
-                          .map(id => nameByDiscordId[id] ?? 'Unknown')
-                          .join(', ')}
-                      </Text>
-                    </Table.Cell>
+                    {hasRosters && (
+                      <Table.Cell className="hidden sm:table-cell">
+                        <Text size="2" className="text-sanguine-bright">
+                          {standing.memberNames.join(', ')}
+                        </Text>
+                      </Table.Cell>
+                    )}
                     <Table.Cell justify="end">
                       <span className="whitespace-nowrap">
                         <Text size="2" className="text-gray-100">

--- a/app/services/audit.server.ts
+++ b/app/services/audit.server.ts
@@ -1,0 +1,19 @@
+/**
+ * Structured audit trail for the admin portal: who signed in, who was denied,
+ * and which admin actions were attempted. One JSON line per event to stdout —
+ * morgan's request lines carry no user identity, and Fly captures stdout, so
+ * this is greppable in `fly logs` without any extra infrastructure.
+ */
+export const audit = (
+  event:
+    | 'auth.login'
+    | 'auth.login_failed'
+    | 'auth.denied'
+    | 'auth.logout'
+    | 'admin.action',
+  details: Record<string, unknown>,
+): void => {
+  console.log(
+    JSON.stringify({ audit: event, ts: new Date().toISOString(), ...details }),
+  );
+};

--- a/app/services/auth.server.ts
+++ b/app/services/auth.server.ts
@@ -38,8 +38,11 @@ export const sessionStorage = createCookieSessionStorage({
   },
 });
 
+// Any of these roles counts as event staff; unset vars are ignored.
 const staffRoleIds = [
   process.env.ADMIN_ROLE_ID,
+  process.env.MOD_ROLE_ID,
+  process.env.OWNER_ROLE_ID,
   process.env.EVENT_TEAM_ROLE_ID,
 ].filter((id): id is string => !!id);
 

--- a/app/services/auth.server.ts
+++ b/app/services/auth.server.ts
@@ -55,18 +55,25 @@ authenticator.use(
       scope: ['identify'],
     },
     async ({ profile }): Promise<ISessionUser> => {
-      const member = await getGuildMember(profile.id);
-      const isStaff =
-        !!member && member.roles.some(role => staffRoleIds.includes(role));
-      const avatarHash = profile.__json.avatar;
-      return {
-        discordId: profile.id,
-        username: member?.nick ?? profile.displayName,
-        avatarUrl: avatarHash
-          ? `https://cdn.discordapp.com/avatars/${profile.id}/${avatarHash}.png?size=64`
-          : null,
-        isStaff,
-      };
+      try {
+        const member = await getGuildMember(profile.id);
+        const isStaff =
+          !!member && member.roles.some(role => staffRoleIds.includes(role));
+        const avatarHash = profile.__json.avatar;
+        return {
+          discordId: profile.id,
+          username: member?.nick ?? profile.displayName,
+          avatarUrl: avatarHash
+            ? `https://cdn.discordapp.com/avatars/${profile.id}/${avatarHash}.png?size=64`
+            : null,
+          isStaff,
+        };
+      } catch (error) {
+        // remix-auth turns this into a failureRedirect; make sure the real cause
+        // also lands in the server log.
+        console.error('Discord auth verify failed:', error);
+        throw error;
+      }
     },
   ),
 );

--- a/app/services/auth.server.ts
+++ b/app/services/auth.server.ts
@@ -16,14 +16,24 @@ export interface ISessionUser {
   isStaff: boolean;
 }
 
+// Same posture as the events API's token check: refuse to boot in production rather
+// than sign staff sessions with a publicly known constant anyone could forge.
+const sessionSecret = process.env.SESSION_SECRET;
+if (!sessionSecret && process.env.NODE_ENV === 'production') {
+  throw new Error('SESSION_SECRET must be set in production');
+}
+
 export const sessionStorage = createCookieSessionStorage({
   cookie: {
     name: '__sanguine_admin',
     httpOnly: true,
     path: '/',
     sameSite: 'lax',
-    secrets: [process.env.SESSION_SECRET ?? 'dev-only-insecure-secret'],
+    secrets: [sessionSecret ?? 'dev-only-insecure-secret'],
     secure: process.env.NODE_ENV === 'production',
+    // Also bounds how long a revoked staff role keeps portal access, since isStaff is
+    // stamped into the session at login.
+    maxAge: 60 * 60 * 24 * 7,
   },
 });
 

--- a/app/services/auth.server.ts
+++ b/app/services/auth.server.ts
@@ -1,0 +1,77 @@
+import * as process from 'process';
+import { createCookieSessionStorage, redirect } from '@remix-run/node';
+import { Authenticator } from 'remix-auth';
+import { DiscordStrategy } from 'remix-auth-discord';
+import { getGuildMember } from '~/services/discord-admin-service.server';
+
+/**
+ * Discord OAuth for the admin portal. Anyone can complete the login; authorization
+ * is the staff-role check (the same roles the events bot honors), stamped into the
+ * session at login time. requireStaff gates every /admin loader and action.
+ */
+export interface ISessionUser {
+  discordId: string;
+  username: string;
+  avatarUrl: string | null;
+  isStaff: boolean;
+}
+
+export const sessionStorage = createCookieSessionStorage({
+  cookie: {
+    name: '__sanguine_admin',
+    httpOnly: true,
+    path: '/',
+    sameSite: 'lax',
+    secrets: [process.env.SESSION_SECRET ?? 'dev-only-insecure-secret'],
+    secure: process.env.NODE_ENV === 'production',
+  },
+});
+
+const staffRoleIds = [
+  process.env.ADMIN_ROLE_ID,
+  process.env.EVENT_TEAM_ROLE_ID,
+].filter((id): id is string => !!id);
+
+export const authenticator = new Authenticator<ISessionUser>(sessionStorage);
+
+authenticator.use(
+  new DiscordStrategy(
+    {
+      clientID: process.env.DISCORD_CLIENT_ID ?? '',
+      clientSecret: process.env.DISCORD_CLIENT_SECRET ?? '',
+      callbackURL:
+        process.env.DISCORD_CALLBACK_URL ??
+        'http://localhost:5173/auth/discord/callback',
+      scope: ['identify'],
+    },
+    async ({ profile }): Promise<ISessionUser> => {
+      const member = await getGuildMember(profile.id);
+      const isStaff =
+        !!member && member.roles.some(role => staffRoleIds.includes(role));
+      const avatarHash = profile.__json.avatar;
+      return {
+        discordId: profile.id,
+        username: member?.nick ?? profile.displayName,
+        avatarUrl: avatarHash
+          ? `https://cdn.discordapp.com/avatars/${profile.id}/${avatarHash}.png?size=64`
+          : null,
+        isStaff,
+      };
+    },
+  ),
+);
+
+/** The logged-in staff member, or a redirect to /login (with ?denied for non-staff). */
+export const requireStaff = async (request: Request): Promise<ISessionUser> => {
+  const user = await authenticator.isAuthenticated(request);
+  if (!user) {
+    throw redirect('/login');
+  }
+  if (!user.isStaff) {
+    throw redirect('/login?denied=1');
+  }
+  return user;
+};
+
+export const getSessionUser = (request: Request): Promise<ISessionUser | null> =>
+  authenticator.isAuthenticated(request);

--- a/app/services/auth.server.ts
+++ b/app/services/auth.server.ts
@@ -3,6 +3,7 @@ import { createCookieSessionStorage, redirect } from '@remix-run/node';
 import { Authenticator } from 'remix-auth';
 import { DiscordStrategy } from 'remix-auth-discord';
 import { getGuildMember } from '~/services/discord-admin-service.server';
+import { audit } from '~/services/audit.server';
 
 /**
  * Discord OAuth for the admin portal. Anyone can complete the login; authorization
@@ -59,10 +60,12 @@ authenticator.use(
         const member = await getGuildMember(profile.id);
         const isStaff =
           !!member && member.roles.some(role => staffRoleIds.includes(role));
+        const username = member?.nick ?? profile.displayName;
         const avatarHash = profile.__json.avatar;
+        audit('auth.login', { discordId: profile.id, username, isStaff });
         return {
           discordId: profile.id,
-          username: member?.nick ?? profile.displayName,
+          username,
           avatarUrl: avatarHash
             ? `https://cdn.discordapp.com/avatars/${profile.id}/${avatarHash}.png?size=64`
             : null,
@@ -71,7 +74,10 @@ authenticator.use(
       } catch (error) {
         // remix-auth turns this into a failureRedirect; make sure the real cause
         // also lands in the server log.
-        console.error('Discord auth verify failed:', error);
+        audit('auth.login_failed', {
+          discordId: profile.id,
+          error: error instanceof Error ? error.message : String(error),
+        });
         throw error;
       }
     },
@@ -85,6 +91,13 @@ export const requireStaff = async (request: Request): Promise<ISessionUser> => {
     throw redirect('/login');
   }
   if (!user.isStaff) {
+    // A signed-in non-staff account reaching for /admin is worth an audit line;
+    // anonymous visitors bounced to /login are just traffic.
+    audit('auth.denied', {
+      discordId: user.discordId,
+      username: user.username,
+      path: new URL(request.url).pathname,
+    });
     throw redirect('/login?denied=1');
   }
   return user;

--- a/app/services/discord-admin-service.server.ts
+++ b/app/services/discord-admin-service.server.ts
@@ -1,0 +1,62 @@
+import * as process from 'process';
+
+/**
+ * Direct Discord REST calls made with the bot token (the same bot user as
+ * sanguine-events). Used by the admin portal: staff-role checks at login and
+ * channel pickers on the race create form.
+ */
+const DISCORD_API_URL = 'https://discord.com/api/v10';
+const DISCORD_TIMEOUT_MS = 8_000;
+
+const botToken = process.env.DISCORD_BOT_TOKEN ?? '';
+const guildId = process.env.DISCORD_SERVER_ID ?? '';
+
+const GUILD_TEXT_CHANNEL = 0;
+
+export interface IGuildMember {
+  roles: string[];
+  nick: string | null;
+}
+
+export interface IGuildTextChannel {
+  id: string;
+  name: string;
+}
+
+const discordFetch = async (path: string): Promise<Response> =>
+  fetch(`${DISCORD_API_URL}${path}`, {
+    headers: { Authorization: `Bot ${botToken}` },
+    signal: AbortSignal.timeout(DISCORD_TIMEOUT_MS),
+  });
+
+/** The guild member for a Discord user id, or null when they're not in the server. */
+export const getGuildMember = async (
+  discordId: string,
+): Promise<IGuildMember | null> => {
+  const response = await discordFetch(`/guilds/${guildId}/members/${discordId}`);
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Discord API returned ${response.status} fetching guild member`);
+  }
+  return (await response.json()) as IGuildMember;
+};
+
+/** All text channels in the server, in sidebar order. */
+export const getGuildTextChannels = async (): Promise<IGuildTextChannel[]> => {
+  const response = await discordFetch(`/guilds/${guildId}/channels`);
+  if (!response.ok) {
+    throw new Error(`Discord API returned ${response.status} fetching channels`);
+  }
+  const channels = (await response.json()) as {
+    id: string;
+    name: string;
+    type: number;
+    position: number;
+  }[];
+  return channels
+    .filter(channel => channel.type === GUILD_TEXT_CHANNEL)
+    .sort((a, b) => a.position - b.position)
+    .map(({ id, name }) => ({ id, name }));
+};

--- a/app/services/events-admin-service.server.ts
+++ b/app/services/events-admin-service.server.ts
@@ -1,0 +1,148 @@
+import * as process from 'process';
+import type { ITileRace } from '~/services/tile-race-service.server';
+
+/**
+ * Client for the sanguine-events admin API (bearer service token). Every call
+ * carries the acting staff member's Discord id in x-acting-user so the events
+ * service attributes announcements and audits to a human, not to the website.
+ */
+const EVENTS_API_URL = process.env.EVENTS_API_URL ?? 'http://localhost:8080';
+const EVENTS_API_TOKEN = process.env.EVENTS_API_TOKEN ?? '';
+const EVENTS_API_TIMEOUT_MS = 10_000;
+
+export interface IAdminTileRace extends ITileRace {
+  channels: {
+    approvalsChannelId: string;
+    announcementsChannelId: string;
+  };
+}
+
+export interface IBoardTileInput {
+  type: 'TASK' | 'GO_BACK' | 'GO_FORWARD';
+  name?: string;
+  description?: string;
+  amount?: number;
+}
+
+export interface ICreateRaceInput {
+  name: string;
+  diceSides: number;
+  tiles: IBoardTileInput[];
+  approvalsChannelId: string;
+  announcementsChannelId: string;
+  days: number;
+}
+
+/** An expected rejection from the events API (validation, rule violations). */
+export class EventsApiError extends Error {
+  constructor(
+    message: string,
+    readonly status: number,
+  ) {
+    super(message);
+    this.name = 'EventsApiError';
+  }
+}
+
+const adminRequest = async <T>(
+  path: string,
+  actingUserId: string,
+  init?: { method?: string; body?: unknown },
+): Promise<T> => {
+  const response = await fetch(`${EVENTS_API_URL}/admin${path}`, {
+    method: init?.method ?? 'POST',
+    headers: {
+      Authorization: `Bearer ${EVENTS_API_TOKEN}`,
+      'x-acting-user': actingUserId,
+      ...(init?.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+    },
+    body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
+    signal: AbortSignal.timeout(EVENTS_API_TIMEOUT_MS),
+  });
+  if (!response.ok) {
+    const payload = (await response.json().catch(() => null)) as {
+      error?: string;
+    } | null;
+    throw new EventsApiError(
+      payload?.error ?? `Events API returned ${response.status}`,
+      response.status,
+    );
+  }
+  return (await response.json()) as T;
+};
+
+/** The open race with admin-only config, or null when there isn't one. */
+export const getAdminRace = async (
+  actingUserId: string,
+): Promise<IAdminTileRace | null> => {
+  try {
+    return await adminRequest<IAdminTileRace>('/races/current', actingUserId, {
+      method: 'GET',
+    });
+  } catch (e) {
+    if (e instanceof EventsApiError && e.status === 404) {
+      return null;
+    }
+    throw e;
+  }
+};
+
+export const createRace = (input: ICreateRaceInput, actingUserId: string) =>
+  adminRequest<{ eventId: string }>('/races', actingUserId, {
+    body: {
+      name: input.name,
+      board: { diceSides: input.diceSides, tiles: input.tiles },
+      approvalsChannelId: input.approvalsChannelId,
+      announcementsChannelId: input.announcementsChannelId,
+      days: input.days,
+    },
+  });
+
+export const startRace = (actingUserId: string) =>
+  adminRequest<{ started: boolean; teamCount: number }>(
+    '/races/current/start',
+    actingUserId,
+  );
+
+export const endRace = (actingUserId: string) =>
+  adminRequest<IAdminTileRace>('/races/current/end', actingUserId);
+
+export const cancelRace = (actingUserId: string) =>
+  adminRequest<{ cancelled: boolean }>('/races/current/cancel', actingUserId);
+
+export const addTeam = (
+  name: string,
+  memberDiscordIds: string[],
+  actingUserId: string,
+) =>
+  adminRequest<{ teamId: string; name: string }>(
+    '/races/current/teams',
+    actingUserId,
+    { body: { name, memberDiscordIds } },
+  );
+
+export const removeTeam = (name: string, actingUserId: string) =>
+  adminRequest<{ removed: boolean }>(
+    `/races/current/teams/${encodeURIComponent(name)}`,
+    actingUserId,
+    { method: 'DELETE' },
+  );
+
+export const moveTeam = (name: string, tile: number, actingUserId: string) =>
+  adminRequest<{ tileIndex: number }>(
+    `/races/current/teams/${encodeURIComponent(name)}/move`,
+    actingUserId,
+    { body: { tile } },
+  );
+
+export const completeTeamTask = (name: string, actingUserId: string) =>
+  adminRequest<{ tileIndex: number }>(
+    `/races/current/teams/${encodeURIComponent(name)}/complete`,
+    actingUserId,
+  );
+
+export const rerollTeam = (name: string, actingUserId: string) =>
+  adminRequest<{ tileIndex: number }>(
+    `/races/current/teams/${encodeURIComponent(name)}/reroll`,
+    actingUserId,
+  );

--- a/app/services/events-admin-service.server.ts
+++ b/app/services/events-admin-service.server.ts
@@ -56,7 +56,9 @@ const adminRequest = async <T>(
     headers: {
       Authorization: `Bearer ${EVENTS_API_TOKEN}`,
       ...(init?.actingUserId ? { 'x-acting-user': init.actingUserId } : {}),
-      ...(init?.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
+      ...(init?.body !== undefined
+        ? { 'Content-Type': 'application/json' }
+        : {}),
     },
     body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
     signal: AbortSignal.timeout(EVENTS_API_TIMEOUT_MS),
@@ -126,6 +128,16 @@ export const addTeam = (
     actingUserId,
     body: { name, memberDiscordIds },
   });
+
+export const updateTeam = (
+  name: string,
+  patch: { name?: string; memberDiscordIds?: string[] },
+  actingUserId: string,
+) =>
+  adminRequest<{ name: string; memberDiscordIds: string[] }>(
+    `/races/current/teams/${encodeURIComponent(name)}`,
+    { method: 'PATCH', actingUserId, body: patch },
+  );
 
 export const removeTeam = (name: string, actingUserId: string) =>
   adminRequest<{ removed: boolean }>(

--- a/app/services/events-admin-service.server.ts
+++ b/app/services/events-admin-service.server.ts
@@ -3,6 +3,7 @@ import type {
   ITileRace,
   ITileRaceStanding,
 } from '~/services/tile-race-service.server';
+import type { IBoardTileInput } from '~/utils/tile-race-board';
 
 /**
  * Client for the sanguine-events admin API (bearer service token). Every call
@@ -24,13 +25,6 @@ export interface IAdminTileRace extends Omit<ITileRace, 'standings'> {
     approvalsChannelId: string;
     announcementsChannelId: string;
   };
-}
-
-export interface IBoardTileInput {
-  type: 'TASK' | 'GO_BACK' | 'GO_FORWARD';
-  name?: string;
-  description?: string;
-  amount?: number;
 }
 
 export interface ICreateRaceInput {

--- a/app/services/events-admin-service.server.ts
+++ b/app/services/events-admin-service.server.ts
@@ -1,5 +1,8 @@
 import * as process from 'process';
-import type { ITileRace } from '~/services/tile-race-service.server';
+import type {
+  ITileRace,
+  ITileRaceStanding,
+} from '~/services/tile-race-service.server';
 
 /**
  * Client for the sanguine-events admin API (bearer service token). Every call
@@ -10,7 +13,13 @@ const EVENTS_API_URL = process.env.EVENTS_API_URL ?? 'http://localhost:8080';
 const EVENTS_API_TOKEN = process.env.EVENTS_API_TOKEN ?? '';
 const EVENTS_API_TIMEOUT_MS = 10_000;
 
-export interface IAdminTileRace extends ITileRace {
+/** Admin standings carry member rosters; the public payload deliberately doesn't. */
+export interface IAdminStanding extends ITileRaceStanding {
+  memberDiscordIds: string[];
+}
+
+export interface IAdminTileRace extends Omit<ITileRace, 'standings'> {
+  standings: IAdminStanding[];
   channels: {
     approvalsChannelId: string;
     announcementsChannelId: string;
@@ -46,14 +55,13 @@ export class EventsApiError extends Error {
 
 const adminRequest = async <T>(
   path: string,
-  actingUserId: string,
-  init?: { method?: string; body?: unknown },
+  init?: { method?: string; body?: unknown; actingUserId?: string },
 ): Promise<T> => {
   const response = await fetch(`${EVENTS_API_URL}/admin${path}`, {
     method: init?.method ?? 'POST',
     headers: {
       Authorization: `Bearer ${EVENTS_API_TOKEN}`,
-      'x-acting-user': actingUserId,
+      ...(init?.actingUserId ? { 'x-acting-user': init.actingUserId } : {}),
       ...(init?.body !== undefined ? { 'Content-Type': 'application/json' } : {}),
     },
     body: init?.body !== undefined ? JSON.stringify(init.body) : undefined,
@@ -71,12 +79,14 @@ const adminRequest = async <T>(
   return (await response.json()) as T;
 };
 
-/** The open race with admin-only config, or null when there isn't one. */
-export const getAdminRace = async (
-  actingUserId: string,
-): Promise<IAdminTileRace | null> => {
+/**
+ * The open race with rosters and admin-only config, or null when there isn't one.
+ * Reads need no acting user — the public /tile-race page also uses this server-side
+ * to resolve rosters, since the public API payload deliberately omits Discord ids.
+ */
+export const getAdminRace = async (): Promise<IAdminTileRace | null> => {
   try {
-    return await adminRequest<IAdminTileRace>('/races/current', actingUserId, {
+    return await adminRequest<IAdminTileRace>('/races/current', {
       method: 'GET',
     });
   } catch (e) {
@@ -88,7 +98,8 @@ export const getAdminRace = async (
 };
 
 export const createRace = (input: ICreateRaceInput, actingUserId: string) =>
-  adminRequest<{ eventId: string }>('/races', actingUserId, {
+  adminRequest<{ eventId: string }>('/races', {
+    actingUserId,
     body: {
       name: input.name,
       board: { diceSides: input.diceSides, tiles: input.tiles },
@@ -101,48 +112,47 @@ export const createRace = (input: ICreateRaceInput, actingUserId: string) =>
 export const startRace = (actingUserId: string) =>
   adminRequest<{ started: boolean; teamCount: number }>(
     '/races/current/start',
-    actingUserId,
+    { actingUserId },
   );
 
 export const endRace = (actingUserId: string) =>
-  adminRequest<IAdminTileRace>('/races/current/end', actingUserId);
+  adminRequest<IAdminTileRace>('/races/current/end', { actingUserId });
 
 export const cancelRace = (actingUserId: string) =>
-  adminRequest<{ cancelled: boolean }>('/races/current/cancel', actingUserId);
+  adminRequest<{ cancelled: boolean }>('/races/current/cancel', {
+    actingUserId,
+  });
 
 export const addTeam = (
   name: string,
   memberDiscordIds: string[],
   actingUserId: string,
 ) =>
-  adminRequest<{ teamId: string; name: string }>(
-    '/races/current/teams',
+  adminRequest<{ teamId: string; name: string }>('/races/current/teams', {
     actingUserId,
-    { body: { name, memberDiscordIds } },
-  );
+    body: { name, memberDiscordIds },
+  });
 
 export const removeTeam = (name: string, actingUserId: string) =>
   adminRequest<{ removed: boolean }>(
     `/races/current/teams/${encodeURIComponent(name)}`,
-    actingUserId,
-    { method: 'DELETE' },
+    { method: 'DELETE', actingUserId },
   );
 
 export const moveTeam = (name: string, tile: number, actingUserId: string) =>
   adminRequest<{ tileIndex: number }>(
     `/races/current/teams/${encodeURIComponent(name)}/move`,
-    actingUserId,
-    { body: { tile } },
+    { actingUserId, body: { tile } },
   );
 
 export const completeTeamTask = (name: string, actingUserId: string) =>
   adminRequest<{ tileIndex: number }>(
     `/races/current/teams/${encodeURIComponent(name)}/complete`,
-    actingUserId,
+    { actingUserId },
   );
 
 export const rerollTeam = (name: string, actingUserId: string) =>
   adminRequest<{ tileIndex: number }>(
     `/races/current/teams/${encodeURIComponent(name)}/reroll`,
-    actingUserId,
+    { actingUserId },
   );

--- a/app/services/osrs-wiki-prices-service.ts
+++ b/app/services/osrs-wiki-prices-service.ts
@@ -192,6 +192,45 @@ export async function fetchOSRSItem(itemId: number): Promise<OSRSItem | null> {
 }
 
 /**
+ * Searches item names (tradeable mapping + untradeables) for the admin image
+ * picker. Every query token must appear in the name; prefix matches rank first.
+ */
+export async function searchItems(
+  query: string,
+  limit: number,
+): Promise<{ name: string; icon: string }[]> {
+  const tokens = query.toLocaleLowerCase().split(/\s+/).filter(Boolean);
+  if (!tokens.length) return [];
+
+  const mapping = await fetchAllMapping().catch(
+    () => ({}) as Record<number, MappingItem>,
+  );
+  const candidates = [
+    ...Object.values(mapping).map(item => ({ id: item.id, name: item.name })),
+    ...Object.entries(untradeableItems).map(([id, name]) => ({
+      id: Number(id),
+      name: toTitleCase(name),
+    })),
+  ];
+
+  return candidates
+    .filter(item => {
+      const lower = item.name.toLocaleLowerCase();
+      return tokens.every(token => lower.includes(token));
+    })
+    .sort((a, b) => {
+      const aStarts = a.name.toLocaleLowerCase().startsWith(tokens[0]) ? 0 : 1;
+      const bStarts = b.name.toLocaleLowerCase().startsWith(tokens[0]) ? 0 : 1;
+      return aStarts - bStarts || a.name.localeCompare(b.name);
+    })
+    .slice(0, limit)
+    .map(item => ({
+      name: item.name,
+      icon: customItemIcons[item.id] ?? wikiItemIconUrl(item.name),
+    }));
+}
+
+/**
  * Fetches all item prices from the OSRS Wiki API with caching
  */
 async function fetchAllPrices(): Promise<PricesResponseData> {

--- a/app/services/tile-race-service.server.ts
+++ b/app/services/tile-race-service.server.ts
@@ -21,6 +21,8 @@ export interface ITileRaceTile {
   /** TASK tiles */
   name?: string;
   description?: string;
+  /** TASK tiles: admin-picked OSRS wiki artwork */
+  imageUrl?: string;
   /** GO_BACK / GO_FORWARD tiles */
   amount?: number;
 }

--- a/app/services/tile-race-service.server.ts
+++ b/app/services/tile-race-service.server.ts
@@ -1,0 +1,70 @@
+import * as process from 'process';
+
+/**
+ * Client for the sanguine-events HTTP API (the events bot's sibling deployable).
+ * The current-race endpoint is public — no auth. This module owns only the I/O
+ * (and is swapped for app/mocks/tile-race-service.server.ts under MOCK_MODE);
+ * board shapes mirror the API's public serializer.
+ */
+const EVENTS_API_URL = process.env.EVENTS_API_URL ?? 'http://localhost:8080';
+
+// A hung connection must abort rather than hold every awaiting loader open.
+const EVENTS_API_TIMEOUT_MS = 8_000;
+
+export type TileType = 'START' | 'FINISH' | 'TASK' | 'GO_BACK' | 'GO_FORWARD';
+
+export type MoveStatus = 'PENDING_SUBMISSION' | 'PENDING_APPROVAL' | 'COMPLETED';
+
+export interface ITileRaceTile {
+  index: number;
+  type: TileType;
+  /** TASK tiles */
+  name?: string;
+  description?: string;
+  /** GO_BACK / GO_FORWARD tiles */
+  amount?: number;
+}
+
+export interface ITileRaceStanding {
+  teamId: string;
+  name: string;
+  memberDiscordIds: string[];
+  /** 1-based finishing place, null while still racing */
+  place: number | null;
+  tileIndex: number;
+  finishIndex: number;
+  currentTask: string | null;
+  moveStatus: MoveStatus | null;
+  isFinished: boolean;
+}
+
+export interface ITileRace {
+  event: {
+    id: string;
+    name: string;
+    status: 'DRAFT' | 'ACTIVE' | 'COMPLETED' | 'CANCELLED';
+    startDate: string;
+    endDate: string;
+  };
+  board: {
+    diceSides: number;
+    /** Task/movement tiles between START and FINISH */
+    tileCount: number;
+    tiles: ITileRaceTile[];
+  };
+  standings: ITileRaceStanding[];
+}
+
+/** The open (draft or running) tile race, or null when there isn't one. */
+export const getCurrentTileRace = async (): Promise<ITileRace | null> => {
+  const response = await fetch(`${EVENTS_API_URL}/races/current`, {
+    signal: AbortSignal.timeout(EVENTS_API_TIMEOUT_MS),
+  });
+  if (response.status === 404) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(`Events API returned ${response.status}`);
+  }
+  return (await response.json()) as ITileRace;
+};

--- a/app/services/tile-race-service.server.ts
+++ b/app/services/tile-race-service.server.ts
@@ -28,7 +28,6 @@ export interface ITileRaceTile {
 export interface ITileRaceStanding {
   teamId: string;
   name: string;
-  memberDiscordIds: string[];
   /** 1-based finishing place, null while still racing */
   place: number | null;
   tileIndex: number;

--- a/app/utils/tile-image-catalog.ts
+++ b/app/utils/tile-image-catalog.ts
@@ -1,0 +1,106 @@
+// Curated boss/activity catalog for the tile-race image picker. Items come from
+// the wiki mapping search (osrs-wiki-prices-service); bosses and minigames have
+// no such index, so they're enumerated here with a known-good wiki filename.
+
+export interface ITileImageOption {
+  label: string;
+  imageUrl: string;
+}
+
+const wiki = (file: string) =>
+  `https://oldschool.runescape.wiki/images/${file}`;
+
+const BOSSES_AND_ACTIVITIES: [label: string, file: string][] = [
+  // Raids
+  ['Chambers of Xeric (Olm)', 'Great_Olm.png'],
+  ['Theatre of Blood (Verzik)', 'Verzik_Vitur.png'],
+  ['Tombs of Amascut (Wardens)', 'Tumeken%27s_Warden_(level-544).png'],
+  // God Wars
+  ['General Graardor', 'General_Graardor.png'],
+  ["Kree'arra", 'Kree%27arra.png'],
+  ['Commander Zilyana', 'Commander_Zilyana.png'],
+  ["K'ril Tsutsaroth", 'K%27ril_Tsutsaroth.png'],
+  ['Nex', 'Nex.png'],
+  // Wilderness
+  ['Revenant maledictus', 'Revenant_maledictus.png'],
+  ['Callisto', 'Callisto.png'],
+  ['Venenatis', 'Venenatis.png'],
+  ["Vet'ion", 'Vet%27ion.png'],
+  ['Scorpia', 'Scorpia.png'],
+  ['Chaos Elemental', 'Chaos_Elemental.png'],
+  ['Chaos Fanatic', 'Chaos_Fanatic.png'],
+  ['Crazy Archaeologist', 'Crazy_archaeologist.png'],
+  ['King Black Dragon', 'King_Black_Dragon.png'],
+  ['Corporeal Beast', 'Corporeal_Beast.png'],
+  // Slayer
+  ['Alchemical Hydra', 'Alchemical_Hydra_(serpentine).png'],
+  ['Cerberus', 'Cerberus.png'],
+  ['Kraken', 'Kraken.png'],
+  ['Abyssal Sire', 'Abyssal_Sire.png'],
+  ['Thermonuclear smoke devil', 'Thermonuclear_smoke_devil.png'],
+  ['Grotesque Guardians', 'Dawn.png'],
+  ['Araxxor', 'Araxxor.png'],
+  ['Skotizo', 'Skotizo.png'],
+  ['Dark beast', 'Dark_beast.png'],
+  // World bosses & DT2
+  ['Vorkath', 'Vorkath.png'],
+  ['Zulrah', 'Zulrah_(serpentine).png'],
+  ['Phantom Muspah', 'Phantom_Muspah_(ranged).png'],
+  ['The Nightmare', 'The_Nightmare.png'],
+  ['Vardorvis', 'Vardorvis.png'],
+  ['The Leviathan', 'The_Leviathan.png'],
+  ['The Whisperer', 'The_Whisperer.png'],
+  ['Duke Sucellus', 'Duke_Sucellus.png'],
+  ['Kalphite Queen', 'Kalphite_Queen.png'],
+  ['Giant Mole', 'Giant_Mole.png'],
+  ['Dagannoth Rex', 'Dagannoth_Rex.png'],
+  ['Dagannoth Prime', 'Dagannoth_Prime.png'],
+  ['Dagannoth Supreme', 'Dagannoth_Supreme.png'],
+  ['Sarachnis', 'Sarachnis.png'],
+  ['Scurrius', 'Scurrius.png'],
+  ['Barrows (Ahrim)', 'Ahrim_the_Blighted.png'],
+  ['Moons of Peril (Eclipse Moon)', 'Eclipse_Moon.png'],
+  ['The Hueycoatl', 'The_Hueycoatl.png'],
+  ['Amoxliatl', 'Amoxliatl.png'],
+  ['Yama', 'Yama_chathead.png'],
+  ['The Gauntlet', 'The_Gauntlet.png'],
+  ['Corrupted Hunllef', 'Corrupted_Hunllef.png'],
+  ['Obor', 'Obor.png'],
+  ['Bryophyta', 'Bryophyta.png'],
+  ['The Mimic', 'The_Mimic.png'],
+  ['Hespori', 'Hespori.png'],
+  // TzHaar
+  ['TzTok-Jad (Fight Caves)', 'TzTok-Jad.png'],
+  ['TzKal-Zuk (Inferno)', 'TzKal-Zuk.png'],
+  ['Sol Heredit (Colosseum)', 'Sol_Heredit.png'],
+  // Skilling bosses / minigames
+  ['Wintertodt (Pyromancer)', 'Pyromancer.png'],
+  ['Tempoross', 'Tempoross.png'],
+  ['Zalcano', 'Zalcano.png'],
+  ['Chompy bird', 'Chompy_bird.png'],
+  // Clues
+  ['Reward casket (beginner)', 'Reward_casket_(beginner)_detail.png'],
+  ['Reward casket (easy)', 'Reward_casket_(easy)_detail.png'],
+  ['Reward casket (medium)', 'Reward_casket_(medium)_detail.png'],
+  ['Reward casket (hard)', 'Reward_casket_(hard)_detail.png'],
+  ['Reward casket (elite)', 'Reward_casket_(elite)_detail.png'],
+  ['Reward casket (master)', 'Reward_casket_(master)_detail.png'],
+];
+
+/**
+ * Boss/activity options whose label contains every query token. Sync and cheap
+ * — the list is small; item search is the async half of the picker's results.
+ */
+export const searchBossImages = (
+  query: string,
+  limit: number,
+): ITileImageOption[] => {
+  const tokens = query.toLocaleLowerCase().split(/\s+/).filter(Boolean);
+  if (!tokens.length) return [];
+  return BOSSES_AND_ACTIVITIES.filter(([label]) => {
+    const lower = label.toLocaleLowerCase();
+    return tokens.every(token => lower.includes(token));
+  })
+    .slice(0, limit)
+    .map(([label, file]) => ({ label, imageUrl: wiki(file) }));
+};

--- a/app/utils/tile-race-board.test.ts
+++ b/app/utils/tile-race-board.test.ts
@@ -1,62 +1,30 @@
 import { describe, expect, it } from 'vitest';
-import { parseBoardScript } from './tile-race-board';
+import { chunkIntoSnakeRows } from './tile-race-board';
 
-describe('parseBoardScript', () => {
-  it('parses tasks, movement tiles, comments, and blank lines', () => {
-    const result = parseBoardScript(
-      [
-        '# the opening stretch',
-        'TASK 60KC @ Barrows | Any member reaches 60 KC',
-        '',
-        'BACK 3',
-        'fwd 2',
-        'TASK Any GWD unique',
-      ].join('\n'),
-    );
-
-    expect(result).toEqual({
-      ok: true,
-      tiles: [
-        {
-          type: 'TASK',
-          name: '60KC @ Barrows',
-          description: 'Any member reaches 60 KC',
-        },
-        { type: 'GO_BACK', amount: 3 },
-        { type: 'GO_FORWARD', amount: 2 },
-        { type: 'TASK', name: 'Any GWD unique' },
-      ],
-    });
+describe('chunkIntoSnakeRows', () => {
+  it('reverses every other row so the path snakes', () => {
+    const rows = chunkIntoSnakeRows([1, 2, 3, 4, 5, 6], 3);
+    expect(rows).toEqual([
+      [1, 2, 3],
+      [6, 5, 4],
+    ]);
   });
 
-  it('keeps pipes after the first as part of the description', () => {
-    const result = parseBoardScript('TASK Solo CoX | no deaths | under 30 min');
-    expect(result).toEqual({
-      ok: true,
-      tiles: [
-        {
-          type: 'TASK',
-          name: 'Solo CoX',
-          description: 'no deaths | under 30 min',
-        },
-      ],
-    });
+  it('pads short rows on the side the path travels from', () => {
+    // row 1 travels right-to-left, so its tiles hug the right edge
+    expect(chunkIntoSnakeRows([1, 2, 3, 4], 3)).toEqual([
+      [1, 2, 3],
+      [null, null, 4],
+    ]);
+    // row 2 travels left-to-right again, so padding falls at the end
+    expect(chunkIntoSnakeRows([1, 2, 3, 4, 5, 6, 7], 3)).toEqual([
+      [1, 2, 3],
+      [6, 5, 4],
+      [7, null, null],
+    ]);
   });
 
-  it('reports every bad line with its line number', () => {
-    const result = parseBoardScript(
-      ['TASK ok', 'TELEPORT 3', 'BACK zero'].join('\n'),
-    );
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.errors).toHaveLength(2);
-      expect(result.errors[0]).toContain('Line 2');
-      expect(result.errors[1]).toContain('Line 3');
-    }
-  });
-
-  it('rejects an empty board', () => {
-    const result = parseBoardScript('# nothing but comments\n\n');
-    expect(result.ok).toBe(false);
+  it('handles an empty list', () => {
+    expect(chunkIntoSnakeRows([], 3)).toEqual([]);
   });
 });

--- a/app/utils/tile-race-board.test.ts
+++ b/app/utils/tile-race-board.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+import { parseBoardScript } from './tile-race-board';
+
+describe('parseBoardScript', () => {
+  it('parses tasks, movement tiles, comments, and blank lines', () => {
+    const result = parseBoardScript(
+      [
+        '# the opening stretch',
+        'TASK 60KC @ Barrows | Any member reaches 60 KC',
+        '',
+        'BACK 3',
+        'fwd 2',
+        'TASK Any GWD unique',
+      ].join('\n'),
+    );
+
+    expect(result).toEqual({
+      ok: true,
+      tiles: [
+        {
+          type: 'TASK',
+          name: '60KC @ Barrows',
+          description: 'Any member reaches 60 KC',
+        },
+        { type: 'GO_BACK', amount: 3 },
+        { type: 'GO_FORWARD', amount: 2 },
+        { type: 'TASK', name: 'Any GWD unique' },
+      ],
+    });
+  });
+
+  it('keeps pipes after the first as part of the description', () => {
+    const result = parseBoardScript('TASK Solo CoX | no deaths | under 30 min');
+    expect(result).toEqual({
+      ok: true,
+      tiles: [
+        {
+          type: 'TASK',
+          name: 'Solo CoX',
+          description: 'no deaths | under 30 min',
+        },
+      ],
+    });
+  });
+
+  it('reports every bad line with its line number', () => {
+    const result = parseBoardScript(
+      ['TASK ok', 'TELEPORT 3', 'BACK zero'].join('\n'),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors).toHaveLength(2);
+      expect(result.errors[0]).toContain('Line 2');
+      expect(result.errors[1]).toContain('Line 3');
+    }
+  });
+
+  it('rejects an empty board', () => {
+    const result = parseBoardScript('# nothing but comments\n\n');
+    expect(result.ok).toBe(false);
+  });
+});

--- a/app/utils/tile-race-board.ts
+++ b/app/utils/tile-race-board.ts
@@ -1,0 +1,82 @@
+import type { IBoardTileInput } from '~/services/events-admin-service.server';
+
+/**
+ * The board script: the admin portal's human-friendly board format, one tile per
+ * line, converted to the events API's board definition. START and FINISH are
+ * added by the events service — the script is only the tiles between them.
+ *
+ *   # comments and blank lines are ignored
+ *   TASK 60KC @ Barrows | Any member reaches 60 Barrows KC
+ *   BACK 3
+ *   FWD 2
+ */
+export type BoardParseResult =
+  | { ok: true; tiles: IBoardTileInput[] }
+  | { ok: false; errors: string[] };
+
+const MOVEMENT_PATTERN = /^(BACK|FWD|FORWARD)\s+(\d+)$/i;
+const TASK_PATTERN = /^TASK\s+(.+)$/i;
+
+const parseLine = (line: string): IBoardTileInput | string => {
+  const movement = line.match(MOVEMENT_PATTERN);
+  if (movement) {
+    const amount = parseInt(movement[2], 10);
+    if (amount < 1) {
+      return 'movement amount must be at least 1';
+    }
+    return {
+      type: movement[1].toUpperCase() === 'BACK' ? 'GO_BACK' : 'GO_FORWARD',
+      amount,
+    };
+  }
+
+  const task = line.match(TASK_PATTERN);
+  if (task) {
+    const [name, ...descriptionParts] = task[1].split('|');
+    if (!name.trim()) {
+      return 'TASK needs a name';
+    }
+    const description = descriptionParts.join('|').trim();
+    return {
+      type: 'TASK',
+      name: name.trim(),
+      ...(description ? { description } : {}),
+    };
+  }
+
+  return 'expected "TASK <name> [| description]", "BACK <n>", or "FWD <n>"';
+};
+
+export const parseBoardScript = (script: string): BoardParseResult => {
+  const parsed = script
+    .split('\n')
+    .map((raw, i) => ({ line: raw.trim(), lineNumber: i + 1 }))
+    .filter(({ line }) => line && !line.startsWith('#'))
+    .map(({ line, lineNumber }) => ({ lineNumber, result: parseLine(line) }));
+
+  const errors = parsed
+    .filter(
+      (p): p is { lineNumber: number; result: string } =>
+        typeof p.result === 'string',
+    )
+    .map(p => `Line ${p.lineNumber}: ${p.result}`);
+
+  if (errors.length) {
+    return { ok: false, errors };
+  }
+
+  const tiles = parsed.map(p => p.result as IBoardTileInput);
+  if (!tiles.length) {
+    return { ok: false, errors: ['The board needs at least one tile'] };
+  }
+  return { ok: true, tiles };
+};
+
+export const BOARD_SCRIPT_PLACEHOLDER = [
+  '# One tile per line, in board order. START and FINISH are added for you.',
+  'TASK 60KC @ Barrows | Any member reaches 60 Barrows KC during the event',
+  'TASK Any GWD unique',
+  'BACK 3',
+  'TASK Any raid unique | Any unique from CoX, ToB, or ToA',
+  'FWD 2',
+].join('\n');

--- a/app/utils/tile-race-board.ts
+++ b/app/utils/tile-race-board.ts
@@ -7,6 +7,8 @@ export interface IBoardTileInput {
   type: BoardTileInputType;
   name?: string;
   description?: string;
+  /** TASK tiles: admin-picked OSRS wiki artwork (wiki-hosted URLs only) */
+  imageUrl?: string;
   amount?: number;
 }
 

--- a/app/utils/tile-race-board.ts
+++ b/app/utils/tile-race-board.ts
@@ -1,82 +1,30 @@
-import type { IBoardTileInput } from '~/services/events-admin-service.server';
+// Shared board helpers for the public tile race page and the admin board builder.
+
+export type BoardTileInputType = 'TASK' | 'GO_BACK' | 'GO_FORWARD';
+
+/** A tile as the events API accepts it at race creation (before START/FINISH are added). */
+export interface IBoardTileInput {
+  type: BoardTileInputType;
+  name?: string;
+  description?: string;
+  amount?: number;
+}
+
+export const BOARD_COLUMNS = 10;
 
 /**
- * The board script: the admin portal's human-friendly board format, one tile per
- * line, converted to the events API's board definition. START and FINISH are
- * added by the events service — the script is only the tiles between them.
- *
- *   # comments and blank lines are ignored
- *   TASK 60KC @ Barrows | Any member reaches 60 Barrows KC
- *   BACK 3
- *   FWD 2
+ * Chutes-and-ladders reading order: rows alternate direction, and short rows keep
+ * their items on the side the path travels from (nulls fill the dead cells).
  */
-export type BoardParseResult =
-  | { ok: true; tiles: IBoardTileInput[] }
-  | { ok: false; errors: string[] };
-
-const MOVEMENT_PATTERN = /^(BACK|FWD|FORWARD)\s+(\d+)$/i;
-const TASK_PATTERN = /^TASK\s+(.+)$/i;
-
-const parseLine = (line: string): IBoardTileInput | string => {
-  const movement = line.match(MOVEMENT_PATTERN);
-  if (movement) {
-    const amount = parseInt(movement[2], 10);
-    if (amount < 1) {
-      return 'movement amount must be at least 1';
-    }
-    return {
-      type: movement[1].toUpperCase() === 'BACK' ? 'GO_BACK' : 'GO_FORWARD',
-      amount,
-    };
-  }
-
-  const task = line.match(TASK_PATTERN);
-  if (task) {
-    const [name, ...descriptionParts] = task[1].split('|');
-    if (!name.trim()) {
-      return 'TASK needs a name';
-    }
-    const description = descriptionParts.join('|').trim();
-    return {
-      type: 'TASK',
-      name: name.trim(),
-      ...(description ? { description } : {}),
-    };
-  }
-
-  return 'expected "TASK <name> [| description]", "BACK <n>", or "FWD <n>"';
-};
-
-export const parseBoardScript = (script: string): BoardParseResult => {
-  const parsed = script
-    .split('\n')
-    .map((raw, i) => ({ line: raw.trim(), lineNumber: i + 1 }))
-    .filter(({ line }) => line && !line.startsWith('#'))
-    .map(({ line, lineNumber }) => ({ lineNumber, result: parseLine(line) }));
-
-  const errors = parsed
-    .filter(
-      (p): p is { lineNumber: number; result: string } =>
-        typeof p.result === 'string',
-    )
-    .map(p => `Line ${p.lineNumber}: ${p.result}`);
-
-  if (errors.length) {
-    return { ok: false, errors };
-  }
-
-  const tiles = parsed.map(p => p.result as IBoardTileInput);
-  if (!tiles.length) {
-    return { ok: false, errors: ['The board needs at least one tile'] };
-  }
-  return { ok: true, tiles };
-};
-
-export const BOARD_SCRIPT_PLACEHOLDER = [
-  '# One tile per line, in board order. START and FINISH are added for you.',
-  'TASK 60KC @ Barrows | Any member reaches 60 Barrows KC during the event',
-  'TASK Any GWD unique',
-  'BACK 3',
-  'TASK Any raid unique | Any unique from CoX, ToB, or ToA',
-  'FWD 2',
-].join('\n');
+export const chunkIntoSnakeRows = <T,>(
+  items: T[],
+  columns: number = BOARD_COLUMNS,
+): (T | null)[][] =>
+  Array.from({ length: Math.ceil(items.length / columns) }, (_, row) => {
+    const slice = items.slice(row * columns, (row + 1) * columns);
+    const padded: (T | null)[] = [
+      ...slice,
+      ...Array<null>(columns - slice.length).fill(null),
+    ];
+    return row % 2 === 1 ? [...padded].reverse() : padded;
+  });

--- a/app/utils/tile-race-images.test.ts
+++ b/app/utils/tile-race-images.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { getTileImageUrl } from './tile-race-images';
+
+const WIKI = 'https://oldschool.runescape.wiki/images';
+
+describe('getTileImageUrl', () => {
+  it('matches a boss name anywhere in freeform task text', () => {
+    expect(getTileImageUrl('Punch Vorkath to death')).toBe(
+      `${WIKI}/Vorkath.png`,
+    );
+    expect(getTileImageUrl('60KC @ Barrows')).toBe(
+      `${WIKI}/Ahrim_the_Blighted.png`,
+    );
+  });
+
+  it('matches clan slang via word-boundary aliases', () => {
+    expect(getTileImageUrl('3KC @ CG')).toBe(`${WIKI}/Corrupted_Hunllef.png`);
+    // but not as a fragment inside another word
+    expect(getTileImageUrl('McGregor challenge')).toBeNull();
+  });
+
+  it('prefers the specific rule over the generic word it contains', () => {
+    expect(getTileImageUrl("Phosani's Nightmare unique")).toBe(
+      `${WIKI}/The_Nightmare.png`,
+    );
+    expect(getTileImageUrl('Corrupted Gauntlet speedrun')).toBe(
+      `${WIKI}/Corrupted_Hunllef.png`,
+    );
+    expect(getTileImageUrl('Gauntlet speedrun')).toBe(
+      `${WIKI}/The_Gauntlet.png`,
+    );
+  });
+
+  it('falls back to the description only when the name has no match', () => {
+    expect(getTileImageUrl('Any GWD unique', 'Any God Wars Dungeon boss')).toBe(
+      `${WIKI}/General_Graardor.png`,
+    );
+    // name match wins even when the description names a different boss
+    expect(
+      getTileImageUrl('100KC @ Zulrah', 'harder than Vorkath, honest'),
+    ).toBe(`${WIKI}/Zulrah_(serpentine).png`);
+  });
+
+  it('returns null rather than guessing for unmatched tasks', () => {
+    expect(getTileImageUrl('Reach 6hr log')).toBeNull();
+    expect(getTileImageUrl(undefined, undefined)).toBeNull();
+  });
+});

--- a/app/utils/tile-race-images.ts
+++ b/app/utils/tile-race-images.ts
@@ -1,0 +1,110 @@
+// Task-tile artwork for the tile race board. Task names are freeform prose
+// ("60KC @ Barrows", "Punch Vorkath to death"), so tiles match by keyword
+// against a dictionary of bosses/activities rather than by exact name.
+
+interface ITileImageRule {
+  keywords: string[];
+  /** OSRS Wiki image filename (URL-encoded where needed). */
+  image: string;
+}
+
+// First matching rule wins — specific names (Phosani, Corrupted Gauntlet)
+// must sit above the generic words they contain (Nightmare, Gauntlet).
+const TILE_IMAGE_RULES: ITileImageRule[] = [
+  // Raids
+  { keywords: ['corrupted gauntlet', 'cg', 'hunllef'], image: 'Corrupted_Hunllef.png' },
+  { keywords: ['gauntlet'], image: 'The_Gauntlet.png' },
+  { keywords: ['chambers of xeric', 'chambers', 'cox', 'olm'], image: 'Great_Olm.png' },
+  { keywords: ['theatre of blood', 'theatre', 'tob', 'verzik'], image: 'Verzik_Vitur.png' },
+  { keywords: ['tombs of amascut', 'tombs', 'toa', 'amascut', 'warden'], image: 'Tumeken%27s_Warden_(level-544).png' },
+  { keywords: ['raid', 'raids'], image: 'Great_Olm.png' },
+  // God Wars
+  { keywords: ['bandos', 'graardor'], image: 'General_Graardor.png' },
+  { keywords: ['armadyl', 'arma', 'kree'], image: 'Kree%27arra.png' },
+  { keywords: ['saradomin', 'zilyana'], image: 'Commander_Zilyana.png' },
+  { keywords: ['zamorak', 'kril', "k'ril"], image: 'K%27ril_Tsutsaroth.png' },
+  { keywords: ['nex'], image: 'Nex.png' },
+  { keywords: ['god wars', 'gwd'], image: 'General_Graardor.png' },
+  // Wilderness
+  { keywords: ['revenant', 'revenants', 'rev', 'revs'], image: 'Revenant_maledictus.png' },
+  { keywords: ['callisto', 'artio'], image: 'Callisto.png' },
+  { keywords: ['venenatis', 'spindel'], image: 'Venenatis.png' },
+  { keywords: ["vet'ion", 'vetion', "calvar'ion", 'calvarion'], image: 'Vet%27ion.png' },
+  { keywords: ['scorpia'], image: 'Scorpia.png' },
+  { keywords: ['chaos elemental'], image: 'Chaos_Elemental.png' },
+  { keywords: ['king black dragon', 'kbd'], image: 'King_Black_Dragon.png' },
+  { keywords: ['corporeal beast', 'corp'], image: 'Corporeal_Beast.png' },
+  // Slayer bosses
+  { keywords: ['alchemical hydra', 'hydra'], image: 'Alchemical_Hydra_(serpentine).png' },
+  { keywords: ['cerberus', 'cerb'], image: 'Cerberus.png' },
+  { keywords: ['kraken'], image: 'Kraken.png' },
+  { keywords: ['abyssal sire', 'sire'], image: 'Abyssal_Sire.png' },
+  { keywords: ['thermonuclear', 'thermy', 'smoke devil'], image: 'Thermonuclear_smoke_devil.png' },
+  { keywords: ['grotesque guardians', 'grotesque', 'dusk', 'dawn'], image: 'Dawn.png' },
+  { keywords: ['araxxor', 'araxyte'], image: 'Araxxor.png' },
+  { keywords: ['skotizo'], image: 'Skotizo.png' },
+  { keywords: ['slayer'], image: 'Slayer_icon.png' },
+  // World / quest bosses
+  { keywords: ["phosani's nightmare", 'phosani'], image: 'The_Nightmare.png' },
+  { keywords: ['nightmare'], image: 'The_Nightmare.png' },
+  { keywords: ['vorkath'], image: 'Vorkath.png' },
+  { keywords: ['zulrah'], image: 'Zulrah_(serpentine).png' },
+  { keywords: ['muspah'], image: 'Phantom_Muspah_(ranged).png' },
+  { keywords: ['vardorvis'], image: 'Vardorvis.png' },
+  { keywords: ['leviathan'], image: 'The_Leviathan.png' },
+  { keywords: ['whisperer'], image: 'The_Whisperer.png' },
+  { keywords: ['duke sucellus', 'duke'], image: 'Duke_Sucellus.png' },
+  { keywords: ['kalphite queen', 'kalphite', 'kq'], image: 'Kalphite_Queen.png' },
+  { keywords: ['giant mole', 'mole'], image: 'Giant_Mole.png' },
+  { keywords: ['dagannoth kings', 'dagannoth', 'dks'], image: 'Dagannoth_Rex.png' },
+  { keywords: ['sarachnis'], image: 'Sarachnis.png' },
+  { keywords: ['scurrius'], image: 'Scurrius.png' },
+  { keywords: ['barrows'], image: 'Ahrim_the_Blighted.png' },
+  { keywords: ['moons of peril', 'moons', 'perilous', 'lunar chest'], image: 'Eclipse_Moon.png' },
+  { keywords: ['hueycoatl', 'huey'], image: 'The_Hueycoatl.png' },
+  { keywords: ['amoxliatl'], image: 'Amoxliatl.png' },
+  { keywords: ['yama'], image: 'Yama_chathead.png' },
+  { keywords: ['chompy'], image: 'Chompy_bird.png' },
+  // TzHaar
+  { keywords: ['inferno', 'zuk'], image: 'TzKal-Zuk.png' },
+  { keywords: ['fight cave', 'fight caves', 'jad'], image: 'TzTok-Jad.png' },
+  { keywords: ['colosseum', 'sol heredit'], image: 'Sol_Heredit.png' },
+  // Skilling activities
+  // The Wintertodt page image is an animated gif; the pyromancer is the static stand-in.
+  { keywords: ['wintertodt', 'todt'], image: 'Pyromancer.png' },
+  { keywords: ['tempoross'], image: 'Tempoross.png' },
+  { keywords: ['zalcano'], image: 'Zalcano.png' },
+  // Clues
+  { keywords: ['master clue'], image: 'Reward_casket_(master)_detail.png' },
+  { keywords: ['elite clue'], image: 'Reward_casket_(elite)_detail.png' },
+  { keywords: ['hard clue'], image: 'Reward_casket_(hard)_detail.png' },
+  { keywords: ['clue', 'clues', 'casket', 'caskets'], image: 'Reward_casket_(hard)_detail.png' },
+];
+
+const escapeRegExp = (s: string) => s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+
+const compiled = TILE_IMAGE_RULES.map(rule => ({
+  // Word boundaries keep short aliases honest: "cg" matches "3KC @ CG" but not "McGrubor".
+  pattern: new RegExp(
+    `(?:^|[^a-z0-9])(?:${rule.keywords.map(escapeRegExp).join('|')})(?=$|[^a-z0-9])`,
+    'i',
+  ),
+  image: rule.image,
+}));
+
+/**
+ * Wiki artwork for a task tile, matched by keyword against its name and
+ * description (name wins when the two disagree). Null when nothing matches —
+ * callers should render the plain tile rather than guess.
+ */
+export const getTileImageUrl = (
+  name?: string,
+  description?: string,
+): string | null => {
+  const match =
+    compiled.find(rule => name && rule.pattern.test(name)) ??
+    compiled.find(rule => description && rule.pattern.test(description));
+  return match
+    ? `https://oldschool.runescape.wiki/images/${match.image}`
+    : null;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,8 @@
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "recharts": "^2.12.1",
+        "remix-auth": "^3.7.0",
+        "remix-auth-discord": "^1.4.1",
         "spin-delay": "^1.2.0",
         "tailwind-merge": "^2.2.1",
         "tailwindcss-radix": "^2.8.0"
@@ -12991,6 +12993,60 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/remix-auth": {
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/remix-auth/-/remix-auth-3.7.0.tgz",
+      "integrity": "sha512-2QVjp2nJVaYxuFBecMQwzixCO7CLSssttLBU5eVlNcNlVeNMmY1g7OkmZ1Ogw9sBcoMXZ18J7xXSK0AISVFcfQ==",
+      "license": "MIT",
+      "dependencies": {
+        "uuid": "^8.3.2"
+      },
+      "peerDependencies": {
+        "@remix-run/react": "^1.0.0 || ^2.0.0",
+        "@remix-run/server-runtime": "^1.0.0 || ^2.0.0"
+      }
+    },
+    "node_modules/remix-auth-discord": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/remix-auth-discord/-/remix-auth-discord-1.4.1.tgz",
+      "integrity": "sha512-H46DiPMYodLwr0TBoLmHy5D2fgfBJH3JjJM1drK5frJoN9XoL/OCvq3TYu/enDbuI2NPLjHLk7k/die4fnv/lQ==",
+      "license": "MIT",
+      "dependencies": {
+        "remix-auth": "^3.6.0",
+        "remix-auth-oauth2": "^1.11.2"
+      },
+      "peerDependencies": {
+        "@remix-run/server-runtime": "^2.1.0"
+      }
+    },
+    "node_modules/remix-auth-oauth2": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/remix-auth-oauth2/-/remix-auth-oauth2-1.11.2.tgz",
+      "integrity": "sha512-5ORP+LMi5CVCA/Wb8Z+FCAJ73Uiy4uyjEzhlVwNBfdAkPOnfxzoi+q/pY/CrueYv3OniCXRM35ZYqkVi3G1UPw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "uuid": "^9.0.1"
+      },
+      "peerDependencies": {
+        "@remix-run/server-runtime": "^1.0.0 || ^2.0.0",
+        "remix-auth": "^3.6.0"
+      }
+    },
+    "node_modules/remix-auth-oauth2/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/require-directory": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -15336,6 +15392,16 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/uvu": {

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "recharts": "^2.12.1",
+    "remix-auth": "^3.7.0",
+    "remix-auth-discord": "^1.4.1",
     "spin-delay": "^1.2.0",
     "tailwind-merge": "^2.2.1",
     "tailwindcss-radix": "^2.8.0"

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -35,6 +35,10 @@ const mockAliases = mockMode
         '~/data/monthly-winners',
         './app/mocks/monthly-winners/index.ts',
       ),
+      mockAlias(
+        '~/services/tile-race-service.server',
+        './app/mocks/tile-race-service.server.ts',
+      ),
     ]
   : [];
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -39,6 +39,15 @@ const mockAliases = mockMode
         '~/services/tile-race-service.server',
         './app/mocks/tile-race-service.server.ts',
       ),
+      mockAlias('~/services/auth.server', './app/mocks/auth.server.ts'),
+      mockAlias(
+        '~/services/discord-admin-service.server',
+        './app/mocks/discord-admin-service.server.ts',
+      ),
+      mockAlias(
+        '~/services/events-admin-service.server',
+        './app/mocks/events-admin-service.server.ts',
+      ),
     ]
   : [];
 


### PR DESCRIPTION
## What

The website half of the tile race event (pairs with aleccaputo/sanguine-events):

- **Public `/tile-race` page** — standings and the live board, rendered as a snake grid with ghosted OSRS wiki artwork on task tiles (admin-picked image, or keyword-matched from the task name as a fallback).
- **Staff admin portal (`/admin`)** — Discord OAuth + staff-role gate, race creation with a visual board builder (typeahead image picker over bosses/activities/items via a staff-gated `/admin/image-search`), team management with member typeahead and inline editing, and per-team overrides (move/complete/reroll).
- **Game-UI button component** — replaces Radix soft buttons, which render as invisible text on the dark theme.
- **Auth/audit logging** — structured JSON lines for logins (with staff flag), denied portal access, logouts, and every attempted admin action.

## Notes

- Rosters resolve to nicknames server-side; raw Discord ids never reach the browser.
- `MOCK_MODE=1` drives the whole portal offline (fixture race, mock auth); `MOCK_EMPTY_RACE=1` shows the create flow.
- Needs `SESSION_SECRET`, Discord OAuth vars, and `EVENTS_API_URL`/`EVENTS_API_TOKEN` in prod. The events-side PR should deploy first (tile `imageUrl` + required `x-acting-user` header).