### PR TITLE
Draft board editing, race rescheduling, larger admin type

### DIFF
--- a/app/components/MemberPicker.tsx
+++ b/app/components/MemberPicker.tsx
@@ -111,7 +111,7 @@ export function MemberPicker({
                 className="flex items-center gap-1.5 rounded-sm border border-gray-700 bg-gray-900 py-0.5 pl-2 pr-1"
               >
                 <Text
-                  size="3"
+                  size="4"
                   className={
                     nickname ? 'text-sanguine-bright' : 'text-gray-400'
                   }
@@ -142,7 +142,7 @@ export function MemberPicker({
           onKeyDown={onKeyDown}
           onBlur={() => setQuery('')}
           placeholder={placeholder}
-          className="text-base"
+          className="text-lg"
           autoComplete="off"
           role="combobox"
           aria-expanded={suggestions.length > 0}
@@ -167,7 +167,7 @@ export function MemberPicker({
                     pick(suggestion.discordId);
                   }}
                   onMouseEnter={() => setActiveIndex(index)}
-                  className={`w-full cursor-pointer px-2 py-1.5 text-left text-base ${
+                  className={`w-full cursor-pointer px-2 py-1.5 text-left text-lg ${
                     index === activeIndex
                       ? 'bg-sanguine-red/10 text-white'
                       : 'text-sanguine-bright'

--- a/app/components/TileImagePicker.tsx
+++ b/app/components/TileImagePicker.tsx
@@ -80,7 +80,7 @@ export function TileImagePicker({ value, onChange, id }: ITileImagePickerProps) 
           className="h-6 w-6 object-contain"
           loading="lazy"
         />
-        <Text size="3" className="text-gray-100">
+        <Text size="4" className="text-gray-100">
           {labelFromUrl(value)}
         </Text>
         <button
@@ -107,7 +107,7 @@ export function TileImagePicker({ value, onChange, id }: ITileImagePickerProps) 
         onKeyDown={onKeyDown}
         onBlur={() => setQuery('')}
         placeholder="Search a boss or item…"
-        className="text-base"
+        className="text-lg"
         autoComplete="off"
         role="combobox"
         aria-expanded={suggestions.length > 0}
@@ -132,7 +132,7 @@ export function TileImagePicker({ value, onChange, id }: ITileImagePickerProps) 
                   pick(suggestion);
                 }}
                 onMouseEnter={() => setActiveIndex(index)}
-                className={`flex w-full cursor-pointer items-center gap-2 px-2 py-1.5 text-left text-base ${
+                className={`flex w-full cursor-pointer items-center gap-2 px-2 py-1.5 text-left text-lg ${
                   index === activeIndex
                     ? 'bg-sanguine-red/10 text-white'
                     : 'text-gray-200'

--- a/app/components/TileRaceBoardBuilder.tsx
+++ b/app/components/TileRaceBoardBuilder.tsx
@@ -118,7 +118,7 @@ export function TileRaceBoardBuilder({
           className="border-t-2 border-t-sanguine-red bg-sanguine-red/[0.04] p-3"
         >
           <Flex align="center" justify="between" gap="3" wrap="wrap">
-            <Text size="3" className="text-osrs-orange">
+            <Text size="4" className="text-osrs-orange">
               Tile {selected + 1} of {tiles.length}
             </Text>
             <Flex gap="2" wrap="wrap">
@@ -150,7 +150,7 @@ export function TileRaceBoardBuilder({
           </Flex>
           <Flex mt="3" gap="4" wrap="wrap" align="end">
             <div className="flex flex-col gap-1.5">
-              <Label className="text-base" htmlFor="tileType">
+              <Label className="text-lg" htmlFor="tileType">
                 Type
               </Label>
               <Select.Root
@@ -170,7 +170,7 @@ export function TileRaceBoardBuilder({
             {selectedTile.type === 'TASK' ? (
               <>
                 <div className="flex min-w-64 flex-1 flex-col gap-1.5">
-                  <Label className="text-base" htmlFor="tileName">
+                  <Label className="text-lg" htmlFor="tileName">
                     Task name
                   </Label>
                   <Input
@@ -180,12 +180,12 @@ export function TileRaceBoardBuilder({
                       updateTile(selected, { name: e.target.value })
                     }
                     placeholder="50KC @ Vorkath"
-                    className="text-base"
+                    className="text-lg"
                     maxLength={100}
                   />
                 </div>
                 <div className="flex min-w-64 flex-1 flex-col gap-1.5">
-                  <Label className="text-base" htmlFor="tileDescription">
+                  <Label className="text-lg" htmlFor="tileDescription">
                     Description (optional)
                   </Label>
                   <Input
@@ -195,12 +195,12 @@ export function TileRaceBoardBuilder({
                       updateTile(selected, { description: e.target.value })
                     }
                     placeholder="Any team member reaches 50 KC gained during the event"
-                    className="text-base"
+                    className="text-lg"
                     maxLength={300}
                   />
                 </div>
                 <div className="flex min-w-64 flex-col gap-1.5">
-                  <Label className="text-base" htmlFor="tileImage">
+                  <Label className="text-lg" htmlFor="tileImage">
                     Image (optional)
                   </Label>
                   <TileImagePicker
@@ -212,7 +212,7 @@ export function TileRaceBoardBuilder({
               </>
             ) : (
               <div className="flex flex-col gap-1.5">
-                <Label className="text-base" htmlFor="tileAmount">
+                <Label className="text-lg" htmlFor="tileAmount">
                   Tiles
                 </Label>
                 <Input
@@ -226,7 +226,7 @@ export function TileRaceBoardBuilder({
                       amount: Math.max(1, Number(e.target.value) || 1),
                     })
                   }
-                  className="w-24 text-base"
+                  className="w-24 text-lg"
                 />
               </div>
             )}
@@ -258,7 +258,7 @@ function BuilderCellView({
   if (cell.kind === 'start' || cell.kind === 'finish') {
     return (
       <div className={`${CELL_BASE} border-gray-800 bg-gray-900`}>
-        <span className="text-xs text-green-400">
+        <span className="text-sm text-green-400">
           {cell.kind === 'start' ? 'START' : 'FINISH'}
         </span>
       </div>
@@ -273,7 +273,7 @@ function BuilderCellView({
         className={`${CELL_BASE} cursor-pointer border-dashed border-gray-600 bg-gray-900 hover:border-gray-400`}
         title="Add a tile"
       >
-        <span className="text-lg text-gray-400">＋</span>
+        <span className="text-xl text-gray-400">＋</span>
       </button>
     );
   }
@@ -285,19 +285,19 @@ function BuilderCellView({
       : null;
   const content =
     tile.type === 'GO_BACK' ? (
-      <span className="text-[11px] leading-tight text-red-400">
+      <span className="text-[13px] leading-tight text-red-400">
         Go back {tile.amount}
       </span>
     ) : tile.type === 'GO_FORWARD' ? (
-      <span className="text-[11px] leading-tight text-sky-400">
+      <span className="text-[13px] leading-tight text-sky-400">
         Forward {tile.amount}
       </span>
     ) : tile.name?.trim() ? (
-      <span className="text-[11px] leading-tight text-gray-200">
+      <span className="text-[13px] leading-tight text-gray-200">
         {tile.name}
       </span>
     ) : (
-      <span className="text-[11px] leading-tight text-gray-500">
+      <span className="text-[13px] leading-tight text-gray-500">
         (unnamed task)
       </span>
     );
@@ -314,7 +314,7 @@ function BuilderCellView({
       }`}
     >
       {imageUrl && <TileArt src={imageUrl} />}
-      <span className="absolute left-1 top-0.5 text-[10px] text-gray-600">
+      <span className="absolute left-1 top-0.5 text-[11px] text-gray-600">
         {index + 1}
       </span>
       {/* relative lifts the label above the absolutely-positioned artwork */}

--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -17,8 +17,8 @@ const VARIANT_CLASSES = {
 } as const;
 
 const SIZE_CLASSES = {
-  sm: 'px-2.5 py-1 text-sm',
-  md: 'px-3.5 py-2 text-base',
+  sm: 'px-3 py-1.5 text-base',
+  md: 'px-4 py-2 text-lg',
 } as const;
 
 export interface ButtonProps

--- a/app/mocks/events-admin-service.server.ts
+++ b/app/mocks/events-admin-service.server.ts
@@ -40,6 +40,12 @@ const ok = async <T>(value: T): Promise<T> => value;
 
 export const createRace = () => ok({ eventId: 'mock-race' });
 export const updateBoard = () => ok({ tileCount: 25, taskCount: 21, diceSides: 6 });
+export const rescheduleRace = () =>
+  ok({
+    name: 'Sanguine Tile Race',
+    startDate: mockAdminRaceBase.event.startDate,
+    endDate: mockAdminRaceBase.event.endDate,
+  });
 export const startRace = () => ok({ started: true, teamCount: 4 });
 export const endRace = async (): Promise<IAdminTileRace> => {
   const race = await getAdminRace();

--- a/app/mocks/events-admin-service.server.ts
+++ b/app/mocks/events-admin-service.server.ts
@@ -15,12 +15,21 @@ export class EventsApiError extends Error {
   }
 }
 
-// MOCK_EMPTY_RACE=1 makes the portal show the create-race form instead of the dashboard
+// MOCK_EMPTY_RACE=1 makes the portal show the create-race form instead of the
+// dashboard; MOCK_DRAFT_RACE=1 serves the fixture as a DRAFT so the pre-start
+// surfaces (board editor, start button) render.
 export const getAdminRace = async (): Promise<IAdminTileRace | null> =>
   process.env.MOCK_EMPTY_RACE === '1'
     ? null
     : {
         ...mockAdminRaceBase,
+        event: {
+          ...mockAdminRaceBase.event,
+          status:
+            process.env.MOCK_DRAFT_RACE === '1'
+              ? 'DRAFT'
+              : mockAdminRaceBase.event.status,
+        },
         channels: {
           approvalsChannelId: '200000000000000002',
           announcementsChannelId: '200000000000000001',
@@ -30,6 +39,7 @@ export const getAdminRace = async (): Promise<IAdminTileRace | null> =>
 const ok = async <T>(value: T): Promise<T> => value;
 
 export const createRace = () => ok({ eventId: 'mock-race' });
+export const updateBoard = () => ok({ tileCount: 25, taskCount: 21, diceSides: 6 });
 export const startRace = () => ok({ started: true, teamCount: 4 });
 export const endRace = async (): Promise<IAdminTileRace> => {
   const race = await getAdminRace();

--- a/app/routes/admin._index.tsx
+++ b/app/routes/admin._index.tsx
@@ -40,12 +40,12 @@ export default function AdminIndex() {
         >
           <Flex align="baseline" justify="between" gap="3" wrap="wrap">
             <Text
-              size="4"
+              size="5"
               className="text-sanguine-bright group-hover:text-white"
             >
               Tile race
             </Text>
-            <Text size="3" className="text-gray-400">
+            <Text size="4" className="text-gray-400">
               {!apiUp ? (
                 <span className="text-red-400">events API unreachable</span>
               ) : race === null ? (
@@ -66,21 +66,21 @@ export default function AdminIndex() {
               )}
             </Text>
           </Flex>
-          <Text as="p" size="3" className="mt-1 text-gray-500">
+          <Text as="p" size="4" className="mt-1 text-gray-500">
             Dice-roll board race. Build the board, manage teams, start the race,
             and fix moves when something goes sideways.
           </Text>
         </Link>
         <div className="border-b border-gray-800 py-3">
           <Flex align="baseline" justify="between" gap="3" wrap="wrap">
-            <Text size="4" className="text-gray-500">
+            <Text size="5" className="text-gray-500">
               Bingo
             </Text>
-            <Text size="3" className="text-gray-600">
+            <Text size="4" className="text-gray-600">
               planned
             </Text>
           </Flex>
-          <Text as="p" size="3" className="mt-1 text-gray-600">
+          <Text as="p" size="4" className="mt-1 text-gray-600">
             Team task boards. Not built yet.
           </Text>
         </div>

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -13,6 +13,7 @@ import {
   useNavigation,
 } from '@remix-run/react';
 import { useEffect, useMemo, useState } from 'react';
+import dayjs from 'dayjs';
 import { Box, Flex, Select, Table, Text } from '@radix-ui/themes';
 import { Button } from '~/components/button';
 import { requireStaff } from '~/services/auth.server';
@@ -28,6 +29,7 @@ import {
   moveTeam,
   removeTeam,
   rerollTeam,
+  rescheduleRace,
   startRace,
   endRace,
   updateBoard,
@@ -214,6 +216,17 @@ export async function action({ request }: ActionFunctionArgs) {
       case 'removeteam':
         await removeTeam(teamName, user.discordId);
         return json({ intent, errors: null });
+      case 'reschedule': {
+        const days = Number(formData.get('days'));
+        if (!Number.isInteger(days) || days < 1 || days > 90) {
+          return json(
+            { intent, errors: ['Days must be a whole number from 1 to 90.'] },
+            { status: 400 },
+          );
+        }
+        await rescheduleRace(days, user.discordId);
+        return json({ intent, errors: null });
+      }
       case 'start':
         await startRace(user.discordId);
         return json({ intent, errors: null });
@@ -452,8 +465,38 @@ function RaceDashboard({
           >
             /tile-race
           </Link>
+          . Runs through{' '}
+          <span className="text-gray-100">
+            {dayjs(event.endDate).format('MMM D, YYYY')}
+          </span>
           .
         </Text>
+        <Form method="post" className="mt-3 flex items-end gap-2">
+          <input type="hidden" name="intent" value="reschedule" />
+          <div className={fieldClass}>
+            <Label className="text-base" htmlFor="rescheduleDays">
+              Planned days (from start)
+            </Label>
+            <Input
+              id="rescheduleDays"
+              name="days"
+              type="number"
+              min={1}
+              max={90}
+              defaultValue={dayjs(event.endDate).diff(
+                dayjs(event.startDate),
+                'day',
+              )}
+              className="w-24 text-base"
+            />
+          </div>
+          <Button type="submit" disabled={submitting}>
+            Update length
+          </Button>
+        </Form>
+        {actionData?.intent === 'reschedule' && actionData.errors && (
+          <ActionErrors errors={actionData.errors} />
+        )}
         {event.status === 'DRAFT' && (
           <Form method="post" className="mt-3">
             <input type="hidden" name="intent" value="start" />

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -30,6 +30,7 @@ import {
   rerollTeam,
   startRace,
   endRace,
+  updateBoard,
   updateTeam,
 } from '~/services/events-admin-service.server';
 import {
@@ -37,7 +38,7 @@ import {
   IGuildTextChannel,
 } from '~/services/discord-admin-service.server';
 import { getUsersWithNicknames } from '~/services/sanguine-service.server';
-import { IBoardTileInput } from '~/utils/tile-race-board';
+import { IBoardTileInput, toBoardTileInputs } from '~/utils/tile-race-board';
 import { Input } from '~/components/input';
 import { Label } from '~/components/label';
 import { IPickerMember, MemberPicker } from '~/components/MemberPicker';
@@ -147,6 +148,28 @@ export async function action({ request }: ActionFunctionArgs) {
             ),
             days: Number(formData.get('days') ?? 14),
           },
+          user.discordId,
+        );
+        return json({ intent, errors: null });
+      }
+      case 'updateboard': {
+        let tiles: IBoardTileInput[];
+        try {
+          tiles = JSON.parse(String(formData.get('board') ?? ''));
+        } catch {
+          return json(
+            { intent, errors: ['The board payload was malformed.'] },
+            { status: 400 },
+          );
+        }
+        if (!Array.isArray(tiles) || !tiles.length) {
+          return json(
+            { intent, errors: ['Add at least one tile to the board.'] },
+            { status: 400 },
+          );
+        }
+        await updateBoard(
+          { diceSides: Number(formData.get('diceSides') ?? 6), tiles },
           user.discordId,
         );
         return json({ intent, errors: null });
@@ -444,6 +467,8 @@ function RaceDashboard({
         )}
       </Box>
 
+      {event.status === 'DRAFT' && <EditBoardSection board={board} />}
+
       <Box>
         <SectionHeading title="Teams" summary={`${standings.length} teams`} />
         {standings.length === 0 ? (
@@ -698,6 +723,66 @@ function TeamRow({
         </Table.Row>
       )}
     </>
+  );
+}
+
+// Draft races only — once the race starts, moves reference tiles by index and
+// the API refuses board edits.
+function EditBoardSection({ board }: { board: IAdminTileRace['board'] }) {
+  const actionData = useActionData<typeof action>();
+  const navigation = useNavigation();
+  const submitting = navigation.state === 'submitting';
+  const [tiles, setTiles] = useState<IBoardTileInput[]>(() =>
+    toBoardTileInputs(board.tiles),
+  );
+  const boardValid =
+    tiles.length > 0 &&
+    tiles.every(tile => tile.type !== 'TASK' || (tile.name ?? '').trim());
+
+  return (
+    <Box>
+      <SectionHeading
+        title="Board"
+        summary="editable until the race starts"
+      />
+      <Form method="post" className="mt-2 flex flex-col gap-3">
+        <input type="hidden" name="intent" value="updateboard" />
+        <input type="hidden" name="board" value={JSON.stringify(tiles)} />
+        <div className={fieldClass}>
+          <Label className="text-base" htmlFor="editDiceSides">
+            Dice sides
+          </Label>
+          <Input
+            id="editDiceSides"
+            name="diceSides"
+            type="number"
+            min={2}
+            max={20}
+            defaultValue={board.diceSides}
+            className="w-24 text-base"
+          />
+        </div>
+        <TileRaceBoardBuilder tiles={tiles} onChange={setTiles} />
+        {actionData?.intent === 'updateboard' && actionData.errors && (
+          <ActionErrors errors={actionData.errors} />
+        )}
+        <Flex align="center" gap="3">
+          <Button
+            variant="primary"
+            type="submit"
+            disabled={submitting || !boardValid}
+            className="w-fit"
+          >
+            {submitting ? 'Saving…' : 'Save board'}
+          </Button>
+          {!boardValid && tiles.length > 0 && (
+            <Text size="2" className="text-gray-500">
+              Every task tile needs a name.
+            </Text>
+          )}
+        </Flex>
+      </Form>
+    </Box>
   );
 }
 

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -278,7 +278,7 @@ export default function AdminTileRace() {
     return (
       <Box>
         <SectionHeading title="Tile race" />
-        <Text as="p" size="3" className="mt-4 text-red-400">
+        <Text as="p" size="4" className="mt-4 text-red-400">
           {apiError}. Is the events API running?
         </Text>
       </Box>
@@ -313,7 +313,7 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
         <input type="hidden" name="intent" value="create" />
         <input type="hidden" name="board" value={JSON.stringify(tiles)} />
         <div className={fieldClass}>
-          <Label className="text-base" htmlFor="name">
+          <Label className="text-lg" htmlFor="name">
             Event name
           </Label>
           <Input
@@ -321,13 +321,13 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
             name="name"
             required
             maxLength={100}
-            className="text-base"
+            className="text-lg"
             placeholder="Sanguine Tile Race III"
           />
         </div>
         <Flex gap="4" wrap="wrap">
           <div className={fieldClass}>
-            <Label className="text-base" htmlFor="diceSides">
+            <Label className="text-lg" htmlFor="diceSides">
               Dice sides
             </Label>
             <Input
@@ -337,11 +337,11 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
               min={2}
               max={20}
               defaultValue={6}
-              className="w-24 text-base"
+              className="w-24 text-lg"
             />
           </div>
           <div className={fieldClass}>
-            <Label className="text-base" htmlFor="days">
+            <Label className="text-lg" htmlFor="days">
               Planned days
             </Label>
             <Input
@@ -351,19 +351,19 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
               min={1}
               max={90}
               defaultValue={14}
-              className="w-24 text-base"
+              className="w-24 text-lg"
             />
           </div>
         </Flex>
         <Flex gap="4" wrap="wrap">
           <div className={fieldClass}>
-            <Label className="text-base" htmlFor="approvalsChannelId">
+            <Label className="text-lg" htmlFor="approvalsChannelId">
               Approvals channel (private)
             </Label>
             <ChannelSelect name="approvalsChannelId" channels={channels} />
           </div>
           <div className={fieldClass}>
-            <Label className="text-base" htmlFor="announcementsChannelId">
+            <Label className="text-lg" htmlFor="announcementsChannelId">
               Announcements channel (public)
             </Label>
             <ChannelSelect name="announcementsChannelId" channels={channels} />
@@ -373,7 +373,7 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
           <Label>
             Board — {tiles.length} tile{tiles.length === 1 ? '' : 's'}
           </Label>
-          <Text size="1" className="text-gray-500">
+          <Text size="2" className="text-gray-500">
             Click ＋ to add a tile, click a tile to edit it. START and FINISH
             are added automatically.
           </Text>
@@ -393,7 +393,7 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
             {submitting ? 'Creating…' : 'Create race (draft)'}
           </Button>
           {!boardValid && tiles.length > 0 && (
-            <Text size="2" className="text-gray-500">
+            <Text size="3" className="text-gray-500">
               Every task tile needs a name.
             </Text>
           )}
@@ -448,7 +448,7 @@ function RaceDashboard({
           title={event.name}
           summary={`${event.status} · ${finished} of ${standings.length} finished`}
         />
-        <Text as="p" size="3" className="mt-2 text-gray-400">
+        <Text as="p" size="4" className="mt-2 text-gray-400">
           <span className="text-gray-100">{board.tileCount}</span> tiles, d
           <span className="text-gray-100">{board.diceSides}</span>. Approvals in{' '}
           <span className="text-gray-100">
@@ -474,7 +474,7 @@ function RaceDashboard({
         <Form method="post" className="mt-3 flex items-end gap-2">
           <input type="hidden" name="intent" value="reschedule" />
           <div className={fieldClass}>
-            <Label className="text-base" htmlFor="rescheduleDays">
+            <Label className="text-lg" htmlFor="rescheduleDays">
               Planned days (from start)
             </Label>
             <Input
@@ -487,7 +487,7 @@ function RaceDashboard({
                 dayjs(event.startDate),
                 'day',
               )}
-              className="w-24 text-base"
+              className="w-24 text-lg"
             />
           </div>
           <Button type="submit" disabled={submitting}>
@@ -624,28 +624,28 @@ function TeamRow({
     <>
       <Table.Row className={zebraStripeClass}>
         <Table.Cell>
-          <Text size="3" className="text-gray-100">
+          <Text size="4" className="text-gray-100">
             {standing.name}
           </Text>
           {rosterNames && (
-            <Text as="p" size="2" className="text-sanguine-bright">
+            <Text as="p" size="3" className="text-sanguine-bright">
               {rosterNames}
             </Text>
           )}
         </Table.Cell>
         <Table.Cell justify="end">
           <span className="whitespace-nowrap">
-            <Text size="3" className="text-gray-100">
+            <Text size="4" className="text-gray-100">
               {standing.tileIndex}
             </Text>
-            <Text size="2" className="text-gray-600">
+            <Text size="3" className="text-gray-600">
               {' '}
               / {standing.finishIndex}
             </Text>
           </span>
         </Table.Cell>
         <Table.Cell className="hidden md:table-cell">
-          <Text size="3" className="text-gray-400">
+          <Text size="4" className="text-gray-400">
             {standing.isFinished ? '🏁 Finished' : standing.currentTask ?? '—'}
           </Text>
         </Table.Cell>
@@ -677,7 +677,7 @@ function TeamRow({
                     max={standing.finishIndex}
                     required
                     placeholder="tile"
-                    className="h-8 w-20 px-2 py-0 text-sm"
+                    className="h-9 w-24 px-2 py-0 text-base"
                   />
                   <Button type="submit" disabled={busy}>
                     Move
@@ -725,7 +725,7 @@ function TeamRow({
               <input type="hidden" name="team" value={standing.name} />
               <div className={fieldClass}>
                 <Label
-                  className="text-base"
+                  className="text-lg"
                   htmlFor={`editName-${standing.teamId}`}
                 >
                   Team name
@@ -736,12 +736,12 @@ function TeamRow({
                   required
                   maxLength={50}
                   defaultValue={standing.name}
-                  className="text-base"
+                  className="text-lg"
                 />
               </div>
               <div className={fieldClass}>
                 <Label
-                  className="text-base"
+                  className="text-lg"
                   htmlFor={`editMembers-${standing.teamId}`}
                 >
                   Members
@@ -792,7 +792,7 @@ function EditBoardSection({ board }: { board: IAdminTileRace['board'] }) {
         <input type="hidden" name="intent" value="updateboard" />
         <input type="hidden" name="board" value={JSON.stringify(tiles)} />
         <div className={fieldClass}>
-          <Label className="text-base" htmlFor="editDiceSides">
+          <Label className="text-lg" htmlFor="editDiceSides">
             Dice sides
           </Label>
           <Input
@@ -802,7 +802,7 @@ function EditBoardSection({ board }: { board: IAdminTileRace['board'] }) {
             min={2}
             max={20}
             defaultValue={board.diceSides}
-            className="w-24 text-base"
+            className="w-24 text-lg"
           />
         </div>
         <TileRaceBoardBuilder tiles={tiles} onChange={setTiles} />
@@ -819,7 +819,7 @@ function EditBoardSection({ board }: { board: IAdminTileRace['board'] }) {
             {submitting ? 'Saving…' : 'Save board'}
           </Button>
           {!boardValid && tiles.length > 0 && (
-            <Text size="2" className="text-gray-500">
+            <Text size="3" className="text-gray-500">
               Every task tile needs a name.
             </Text>
           )}
@@ -842,7 +842,7 @@ function AddTeamForm({ members }: { members: IPickerMember[] }) {
       <Form method="post" className="mt-2 flex flex-col gap-3">
         <input type="hidden" name="intent" value="addteam" />
         <div className={fieldClass}>
-          <Label className="text-base" htmlFor="teamName">
+          <Label className="text-lg" htmlFor="teamName">
             Team name
           </Label>
           <Input
@@ -850,12 +850,12 @@ function AddTeamForm({ members }: { members: IPickerMember[] }) {
             name="name"
             required
             maxLength={50}
-            className="text-base"
+            className="text-lg"
             placeholder="Blood Reapers"
           />
         </div>
         <div className={fieldClass}>
-          <Label className="text-base" htmlFor="members">
+          <Label className="text-lg" htmlFor="members">
             Members
           </Label>
           <MemberPicker id="members" members={members} inputName="members" />
@@ -880,7 +880,7 @@ function ActionErrors({ errors }: { errors: string[] }) {
   return (
     <Box mt="2">
       {errors.map(error => (
-        <Text key={error} as="p" size="3" className="text-red-400">
+        <Text key={error} as="p" size="4" className="text-red-400">
           {error}
         </Text>
       ))}

--- a/app/routes/admin.tsx
+++ b/app/routes/admin.tsx
@@ -24,7 +24,7 @@ export default function AdminLayout() {
         className="mb-6 border-b-2 border-b-sanguine-red pb-2"
       >
         <Link to="/admin">
-          <Text size="3" className="text-osrs-orange hover:text-white">
+          <Text size="4" className="text-osrs-orange hover:text-white">
             Events admin
           </Text>
         </Link>
@@ -38,7 +38,7 @@ export default function AdminLayout() {
               className="rounded-sm"
             />
           )}
-          <Text size="3" className="text-sanguine-bright">
+          <Text size="4" className="text-sanguine-bright">
             {user.username}
           </Text>
           <Form method="post" action="/logout">

--- a/app/services/events-admin-service.server.ts
+++ b/app/services/events-admin-service.server.ts
@@ -119,6 +119,13 @@ export const updateBoard = (
     },
   );
 
+/** Re-plan the race length: endDate = startDate + days (draft or running). */
+export const rescheduleRace = (days: number, actingUserId: string) =>
+  adminRequest<{ name: string; startDate: string; endDate: string }>(
+    '/races/current',
+    { method: 'PATCH', actingUserId, body: { days } },
+  );
+
 export const startRace = (actingUserId: string) =>
   adminRequest<{ started: boolean; teamCount: number }>(
     '/races/current/start',

--- a/app/services/events-admin-service.server.ts
+++ b/app/services/events-admin-service.server.ts
@@ -105,6 +105,20 @@ export const createRace = (input: ICreateRaceInput, actingUserId: string) =>
     },
   });
 
+/** Replace the board of the open race — the API rejects this once the race is ACTIVE. */
+export const updateBoard = (
+  input: { diceSides: number; tiles: IBoardTileInput[] },
+  actingUserId: string,
+) =>
+  adminRequest<{ tileCount: number; taskCount: number; diceSides: number }>(
+    '/races/current/board',
+    {
+      method: 'PUT',
+      actingUserId,
+      body: { board: { diceSides: input.diceSides, tiles: input.tiles } },
+    },
+  );
+
 export const startRace = (actingUserId: string) =>
   adminRequest<{ started: boolean; teamCount: number }>(
     '/races/current/start',

--- a/app/utils/tile-race-board.test.ts
+++ b/app/utils/tile-race-board.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { chunkIntoSnakeRows } from './tile-race-board';
+import {
+  chunkIntoSnakeRows,
+  IBoardTileLike,
+  toBoardTileInputs,
+} from './tile-race-board';
 
 describe('chunkIntoSnakeRows', () => {
   it('reverses every other row so the path snakes', () => {
@@ -26,5 +30,31 @@ describe('chunkIntoSnakeRows', () => {
 
   it('handles an empty list', () => {
     expect(chunkIntoSnakeRows([], 3)).toEqual([]);
+  });
+});
+
+describe('toBoardTileInputs', () => {
+  it('drops START/FINISH and keeps only each type’s own fields', () => {
+    const served: IBoardTileLike[] = [
+      { type: 'START', name: 'Start' },
+      {
+        type: 'TASK',
+        name: 'Punch Vorkath to death',
+        imageUrl: 'https://oldschool.runescape.wiki/images/Vorkath.png',
+        // a stray amount from a hand-edited payload must not survive on a TASK
+        amount: 3,
+      },
+      { type: 'GO_BACK', amount: 2, name: 'ignored' },
+      { type: 'FINISH', name: 'Finish' },
+    ];
+    expect(toBoardTileInputs(served)).toEqual([
+      {
+        type: 'TASK',
+        name: 'Punch Vorkath to death',
+        description: undefined,
+        imageUrl: 'https://oldschool.runescape.wiki/images/Vorkath.png',
+      },
+      { type: 'GO_BACK', amount: 2 },
+    ]);
   });
 });

--- a/app/utils/tile-race-board.ts
+++ b/app/utils/tile-race-board.ts
@@ -14,6 +14,41 @@ export interface IBoardTileInput {
 
 export const BOARD_COLUMNS = 10;
 
+/** A board tile as any race payload serves it (superset of the input shape). */
+export interface IBoardTileLike {
+  type: 'START' | 'FINISH' | BoardTileInputType;
+  name?: string;
+  description?: string;
+  imageUrl?: string;
+  amount?: number;
+}
+
+/**
+ * A served board back into builder inputs: START/FINISH drop (the API re-adds
+ * them), and each tile keeps only the fields its type submits.
+ */
+export const toBoardTileInputs = (
+  tiles: IBoardTileLike[],
+): IBoardTileInput[] =>
+  tiles.flatMap((tile): IBoardTileInput[] => {
+    switch (tile.type) {
+      case 'TASK':
+        return [
+          {
+            type: tile.type,
+            name: tile.name ?? '',
+            description: tile.description,
+            imageUrl: tile.imageUrl,
+          },
+        ];
+      case 'GO_BACK':
+      case 'GO_FORWARD':
+        return [{ type: tile.type, amount: tile.amount ?? 1 }];
+      default:
+        return [];
+    }
+  });
+
 /**
  * Chutes-and-ladders reading order: rows alternate direction, and short rows keep
  * their items on the side the path travels from (nulls fill the dead cells).


### PR DESCRIPTION
## What

Follow-ups to #23 for the admin portal:

- **Edit the board while a race is a draft** — the dashboard grows a "Board" section (draft only): the same visual builder, prefilled with the live tiles and dice sides, saving through the new `PUT /admin/races/current/board`. Disappears once the race starts.
- **Change the race length** — the header narrates "Runs through <date>" and a "Planned days (from start)" field reschedules via `PATCH /admin/races/current`. Works on draft and running races.
- **Bigger admin type** — every admin surface moves up one size notch (prose and cells 16→18px, labels/inputs/buttons to match, board-builder tile labels 11→13px). Public pages untouched.
- `MOCK_DRAFT_RACE=1` serves the fixture as a DRAFT so the pre-start dashboard is drivable offline.

Merge the sanguine-events `race-editing` PR first — both new endpoints live there.