### PR TITLE
Board edit versioning + counted tiles in the builder

### DIFF
--- a/app/components/TileRaceBoardBuilder.tsx
+++ b/app/components/TileRaceBoardBuilder.tsx
@@ -199,6 +199,26 @@ export function TileRaceBoardBuilder({
                     maxLength={300}
                   />
                 </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label className="text-lg" htmlFor="tileQuantity">
+                    Drops needed
+                  </Label>
+                  <Input
+                    id="tileQuantity"
+                    type="number"
+                    min={1}
+                    max={1000}
+                    value={selectedTile.quantity ?? 1}
+                    onChange={e => {
+                      const quantity = Math.max(1, Number(e.target.value) || 1);
+                      // 1 is an ordinary tile — keep the payload clean
+                      updateTile(selected, {
+                        quantity: quantity > 1 ? quantity : undefined,
+                      });
+                    }}
+                    className="w-24 text-lg"
+                  />
+                </div>
                 <div className="flex min-w-64 flex-col gap-1.5">
                   <Label className="text-lg" htmlFor="tileImage">
                     Image (optional)
@@ -317,6 +337,11 @@ function BuilderCellView({
       <span className="absolute left-1 top-0.5 text-[11px] text-gray-600">
         {index + 1}
       </span>
+      {tile.type === 'TASK' && (tile.quantity ?? 1) > 1 && (
+        <span className="absolute right-1 top-0.5 text-[11px] text-osrs-gold">
+          ×{tile.quantity}
+        </span>
+      )}
       {/* relative lifts the label above the absolutely-positioned artwork */}
       <span className="relative">{content}</span>
     </button>

--- a/app/mocks/events-admin-service.server.ts
+++ b/app/mocks/events-admin-service.server.ts
@@ -39,7 +39,8 @@ export const getAdminRace = async (): Promise<IAdminTileRace | null> =>
 const ok = async <T>(value: T): Promise<T> => value;
 
 export const createRace = () => ok({ eventId: 'mock-race' });
-export const updateBoard = () => ok({ tileCount: 25, taskCount: 21, diceSides: 6 });
+export const updateBoard = () =>
+  ok({ tileCount: 25, taskCount: 21, diceSides: 6, version: 1 });
 export const rescheduleRace = () =>
   ok({
     name: 'Sanguine Tile Race',

--- a/app/mocks/tile-race-service.server.ts
+++ b/app/mocks/tile-race-service.server.ts
@@ -38,7 +38,14 @@ const innerTiles: ITileRaceTile[] = [
   task('Melee fight cave', 'Complete the Fight Caves using only melee'),
   goForward(3),
   task('100KC @ Vorkath'),
-  task('Any barrows unique'),
+  {
+    // Counted tile: each approved drop ticks progress, 10 complete it
+    index: 0,
+    type: 'TASK',
+    name: '10 KBD heads',
+    description: 'One head per approved submission — ten clear the tile',
+    quantity: 10,
+  },
   task('3000 pts in one Wintertodt game'),
   goBack(3),
   {

--- a/app/mocks/tile-race-service.server.ts
+++ b/app/mocks/tile-race-service.server.ts
@@ -43,7 +43,7 @@ const innerTiles: ITileRaceTile[] = [
     index: 0,
     type: 'TASK',
     name: '10 KBD heads',
-    description: 'One head per approved submission — ten clear the tile',
+    description: 'One head per approved submission, ten clear the tile',
     quantity: 10,
   },
   task('3000 pts in one Wintertodt game'),

--- a/app/routes/admin._index.tsx
+++ b/app/routes/admin._index.tsx
@@ -49,16 +49,16 @@ export default function AdminIndex() {
               {!apiUp ? (
                 <span className="text-red-400">events API unreachable</span>
               ) : race === null ? (
-                'no open race — create one'
+                'no open race, create one'
               ) : race.status === 'DRAFT' ? (
                 <>
-                  {race.name} — draft,{' '}
+                  {race.name}: draft,{' '}
                   <span className="text-gray-100">{race.teamCount}</span> team
                   {race.teamCount === 1 ? '' : 's'}
                 </>
               ) : (
                 <>
-                  {race.name} — active,{' '}
+                  {race.name}: active,{' '}
                   <span className="text-gray-100">{race.finishedCount}</span> of{' '}
                   <span className="text-gray-100">{race.teamCount}</span>{' '}
                   finished

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -171,7 +171,11 @@ export async function action({ request }: ActionFunctionArgs) {
           );
         }
         await updateBoard(
-          { diceSides: Number(formData.get('diceSides') ?? 6), tiles },
+          {
+            diceSides: Number(formData.get('diceSides') ?? 6),
+            tiles,
+            version: Number(formData.get('version') ?? 0),
+          },
           user.discordId,
         );
         return json({ intent, errors: null });
@@ -791,6 +795,8 @@ function EditBoardSection({ board }: { board: IAdminTileRace['board'] }) {
       <Form method="post" className="mt-2 flex flex-col gap-3">
         <input type="hidden" name="intent" value="updateboard" />
         <input type="hidden" name="board" value={JSON.stringify(tiles)} />
+        {/* Version the tiles were loaded at — a concurrent save 409s instead of clobbering */}
+        <input type="hidden" name="version" value={board.version ?? 0} />
         <div className={fieldClass}>
           <Label className="text-lg" htmlFor="editDiceSides">
             Dice sides

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -49,7 +49,7 @@ import { SectionHeading } from '~/components/SectionHeading';
 import { EmptyState } from '~/components/EmptyState';
 import { zebraStripeClass } from '~/utils/styles';
 
-export const meta: MetaFunction = () => [{ title: 'Events Admin — Tile Race' }];
+export const meta: MetaFunction = () => [{ title: 'Tile Race | Events Admin' }];
 
 // The clan roster feeding the member typeahead — same source the rest of the
 // site uses for nickname resolution.
@@ -266,7 +266,7 @@ export async function action({ request }: ActionFunctionArgs) {
       return json(
         {
           intent,
-          errors: ['The events API is unreachable — try again shortly.'],
+          errors: ['The events API is unreachable. Try again shortly.'],
         },
         { status: 503 },
       );
@@ -375,7 +375,7 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
         </Flex>
         <div className={fieldClass}>
           <Label>
-            Board — {tiles.length} tile{tiles.length === 1 ? '' : 's'}
+            Board: {tiles.length} tile{tiles.length === 1 ? '' : 's'}
           </Label>
           <Text size="2" className="text-gray-500">
             Click ＋ to add a tile, click a tile to edit it. START and FINISH
@@ -505,7 +505,7 @@ function RaceDashboard({
           <Form method="post" className="mt-3">
             <input type="hidden" name="intent" value="start" />
             <Button variant="primary" type="submit" disabled={submitting}>
-              Start race — roll first tasks
+              Start race and roll first tasks
             </Button>
           </Form>
         )}
@@ -519,7 +519,7 @@ function RaceDashboard({
       <Box>
         <SectionHeading title="Teams" summary={`${standings.length} teams`} />
         {standings.length === 0 ? (
-          <EmptyState>No teams yet — add the first one below.</EmptyState>
+          <EmptyState>No teams yet. Add the first one below.</EmptyState>
         ) : (
           <Table.Root size="3" mt="2">
             <Table.Header>

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -9,7 +9,7 @@ import {
 } from '~/services/auth.server';
 import { PageHeader } from '~/components/PageHeader';
 
-export const meta: MetaFunction = () => [{ title: 'Events Admin — Login' }];
+export const meta: MetaFunction = () => [{ title: 'Login | Events Admin' }];
 
 export async function loader({ request }: LoaderFunctionArgs) {
   const user = await getSessionUser(request);

--- a/app/routes/tile-race.tsx
+++ b/app/routes/tile-race.tsx
@@ -22,7 +22,7 @@ export const meta: MetaFunction = () => {
     {
       name: 'description',
       content:
-        'The Sanguine tile race: teams roll their way across a board of PvM tasks — live positions, current tasks, and the board itself.',
+        'The Sanguine tile race: teams roll their way across a board of PvM tasks, with live positions, current tasks, and the board itself.',
     },
   ];
 };
@@ -90,7 +90,7 @@ const tileTitle = (tile: ITileRaceTile): string => {
       return `Go forward ${tile.amount} tiles`;
     case 'TASK': {
       const base = tile.description
-        ? `${tile.name} — ${tile.description}`
+        ? `${tile.name}: ${tile.description}`
         : (tile.name ?? 'Task');
       return (tile.quantity ?? 1) > 1
         ? `${base} (${tile.quantity} approved drops to complete)`
@@ -250,7 +250,7 @@ export default function TileRace() {
           `${leader.name} leads from tile ${leader.tileIndex}.`}
         {event.status === 'COMPLETED' &&
           winner &&
-          `The race is over — ${winner.name} took 1st.`}
+          `The race is over. ${winner.name} took 1st.`}
       </PageHeader>
 
       <Flex direction="column" gap="6">

--- a/app/routes/tile-race.tsx
+++ b/app/routes/tile-race.tsx
@@ -88,10 +88,14 @@ const tileTitle = (tile: ITileRaceTile): string => {
       return `Go back ${tile.amount} tiles`;
     case 'GO_FORWARD':
       return `Go forward ${tile.amount} tiles`;
-    case 'TASK':
-      return tile.description
+    case 'TASK': {
+      const base = tile.description
         ? `${tile.name} — ${tile.description}`
         : (tile.name ?? 'Task');
+      return (tile.quantity ?? 1) > 1
+        ? `${base} (${tile.quantity} approved drops to complete)`
+        : base;
+    }
   }
 };
 
@@ -151,6 +155,11 @@ function TileCell({
       <span className="absolute left-1 top-0.5 text-[9px] text-gray-600">
         {tile.index}
       </span>
+      {tile.type === 'TASK' && (tile.quantity ?? 1) > 1 && (
+        <span className="absolute right-1 top-0.5 text-[9px] text-osrs-gold">
+          ×{tile.quantity}
+        </span>
+      )}
       {/* relative lifts the label above the absolutely-positioned artwork */}
       <span className="relative">{content}</span>
       {teamsHere.length > 0 && (

--- a/app/services/events-admin-service.server.ts
+++ b/app/services/events-admin-service.server.ts
@@ -105,19 +105,28 @@ export const createRace = (input: ICreateRaceInput, actingUserId: string) =>
     },
   });
 
-/** Replace the board of the open race — the API rejects this once the race is ACTIVE. */
+/**
+ * Replace the board of the open race. The API rejects this once the race is
+ * ACTIVE, and 409s if the board's version moved since it was loaded (someone
+ * else saved first) rather than silently overwriting their edits.
+ */
 export const updateBoard = (
-  input: { diceSides: number; tiles: IBoardTileInput[] },
+  input: { diceSides: number; tiles: IBoardTileInput[]; version: number },
   actingUserId: string,
 ) =>
-  adminRequest<{ tileCount: number; taskCount: number; diceSides: number }>(
-    '/races/current/board',
-    {
-      method: 'PUT',
-      actingUserId,
-      body: { board: { diceSides: input.diceSides, tiles: input.tiles } },
+  adminRequest<{
+    tileCount: number;
+    taskCount: number;
+    diceSides: number;
+    version: number;
+  }>('/races/current/board', {
+    method: 'PUT',
+    actingUserId,
+    body: {
+      board: { diceSides: input.diceSides, tiles: input.tiles },
+      version: input.version,
     },
-  );
+  });
 
 /** Re-plan the race length: endDate = startDate + days (draft or running). */
 export const rescheduleRace = (days: number, actingUserId: string) =>

--- a/app/services/tile-race-service.server.ts
+++ b/app/services/tile-race-service.server.ts
@@ -52,6 +52,8 @@ export interface ITileRace {
     /** Task/movement tiles between START and FINISH */
     tileCount: number;
     tiles: ITileRaceTile[];
+    /** Admin payload only: optimistic-concurrency token for board edits */
+    version?: number;
   };
   standings: ITileRaceStanding[];
 }

--- a/app/services/tile-race-service.server.ts
+++ b/app/services/tile-race-service.server.ts
@@ -23,6 +23,8 @@ export interface ITileRaceTile {
   description?: string;
   /** TASK tiles: admin-picked OSRS wiki artwork */
   imageUrl?: string;
+  /** TASK tiles: approved submissions required to complete the tile (absent = 1) */
+  quantity?: number;
   /** GO_BACK / GO_FORWARD tiles */
   amount?: number;
 }

--- a/app/utils/tile-race-board.ts
+++ b/app/utils/tile-race-board.ts
@@ -9,6 +9,8 @@ export interface IBoardTileInput {
   description?: string;
   /** TASK tiles: admin-picked OSRS wiki artwork (wiki-hosted URLs only) */
   imageUrl?: string;
+  /** TASK tiles: approved submissions required to complete the tile (1 = ordinary) */
+  quantity?: number;
   amount?: number;
 }
 
@@ -20,6 +22,7 @@ export interface IBoardTileLike {
   name?: string;
   description?: string;
   imageUrl?: string;
+  quantity?: number;
   amount?: number;
 }
 
@@ -39,6 +42,7 @@ export const toBoardTileInputs = (
             name: tile.name ?? '',
             description: tile.description,
             imageUrl: tile.imageUrl,
+            quantity: tile.quantity,
           },
         ];
       case 'GO_BACK':


### PR DESCRIPTION
Companion to sanguine-events #3 (merge that first). Two features, one branch:

## Board edit versioning

The board editor carries the version it loaded in a hidden field; a save that lost a race to another editor surfaces the API's 409 message inline ("Someone else changed the board while you were editing. Reload and reapply your edits.") instead of silently overwriting their work. Successful saves keep working back-to-back since Remix revalidation refreshes the version.

## Counted tiles

The builder's task editor gains a "Drops needed" field (default 1; values above 1 mark the tile as counted). Counted tiles wear a small gold ×N badge on both the builder and public board, and the public hover title notes "(10 approved drops to complete)". Team progress needs no web changes: the events API bakes it into `currentTask` ("10 KBD heads (3/10)"), which the standings tables already render. Mock fixture gains a counted tile for offline dev.
