### PR TITLE
Counted tiles: quantity field in the builder, progress on the board

### DIFF
--- a/app/components/TileRaceBoardBuilder.tsx
+++ b/app/components/TileRaceBoardBuilder.tsx
@@ -199,6 +199,26 @@ export function TileRaceBoardBuilder({
                     maxLength={300}
                   />
                 </div>
+                <div className="flex flex-col gap-1.5">
+                  <Label className="text-lg" htmlFor="tileQuantity">
+                    Drops needed
+                  </Label>
+                  <Input
+                    id="tileQuantity"
+                    type="number"
+                    min={1}
+                    max={1000}
+                    value={selectedTile.quantity ?? 1}
+                    onChange={e => {
+                      const quantity = Math.max(1, Number(e.target.value) || 1);
+                      // 1 is an ordinary tile — keep the payload clean
+                      updateTile(selected, {
+                        quantity: quantity > 1 ? quantity : undefined,
+                      });
+                    }}
+                    className="w-24 text-lg"
+                  />
+                </div>
                 <div className="flex min-w-64 flex-col gap-1.5">
                   <Label className="text-lg" htmlFor="tileImage">
                     Image (optional)
@@ -317,6 +337,11 @@ function BuilderCellView({
       <span className="absolute left-1 top-0.5 text-[11px] text-gray-600">
         {index + 1}
       </span>
+      {tile.type === 'TASK' && (tile.quantity ?? 1) > 1 && (
+        <span className="absolute right-1 top-0.5 text-[11px] text-osrs-gold">
+          ×{tile.quantity}
+        </span>
+      )}
       {/* relative lifts the label above the absolutely-positioned artwork */}
       <span className="relative">{content}</span>
     </button>

--- a/app/mocks/tile-race-service.server.ts
+++ b/app/mocks/tile-race-service.server.ts
@@ -38,7 +38,14 @@ const innerTiles: ITileRaceTile[] = [
   task('Melee fight cave', 'Complete the Fight Caves using only melee'),
   goForward(3),
   task('100KC @ Vorkath'),
-  task('Any barrows unique'),
+  {
+    // Counted tile: each approved drop ticks progress, 10 complete it
+    index: 0,
+    type: 'TASK',
+    name: '10 KBD heads',
+    description: 'One head per approved submission — ten clear the tile',
+    quantity: 10,
+  },
   task('3000 pts in one Wintertodt game'),
   goBack(3),
   {

--- a/app/routes/tile-race.tsx
+++ b/app/routes/tile-race.tsx
@@ -88,10 +88,14 @@ const tileTitle = (tile: ITileRaceTile): string => {
       return `Go back ${tile.amount} tiles`;
     case 'GO_FORWARD':
       return `Go forward ${tile.amount} tiles`;
-    case 'TASK':
-      return tile.description
+    case 'TASK': {
+      const base = tile.description
         ? `${tile.name} — ${tile.description}`
         : (tile.name ?? 'Task');
+      return (tile.quantity ?? 1) > 1
+        ? `${base} (${tile.quantity} approved drops to complete)`
+        : base;
+    }
   }
 };
 
@@ -151,6 +155,11 @@ function TileCell({
       <span className="absolute left-1 top-0.5 text-[9px] text-gray-600">
         {tile.index}
       </span>
+      {tile.type === 'TASK' && (tile.quantity ?? 1) > 1 && (
+        <span className="absolute right-1 top-0.5 text-[9px] text-osrs-gold">
+          ×{tile.quantity}
+        </span>
+      )}
       {/* relative lifts the label above the absolutely-positioned artwork */}
       <span className="relative">{content}</span>
       {teamsHere.length > 0 && (

--- a/app/services/tile-race-service.server.ts
+++ b/app/services/tile-race-service.server.ts
@@ -23,6 +23,8 @@ export interface ITileRaceTile {
   description?: string;
   /** TASK tiles: admin-picked OSRS wiki artwork */
   imageUrl?: string;
+  /** TASK tiles: approved submissions required to complete the tile (absent = 1) */
+  quantity?: number;
   /** GO_BACK / GO_FORWARD tiles */
   amount?: number;
 }

--- a/app/utils/tile-race-board.ts
+++ b/app/utils/tile-race-board.ts
@@ -9,6 +9,8 @@ export interface IBoardTileInput {
   description?: string;
   /** TASK tiles: admin-picked OSRS wiki artwork (wiki-hosted URLs only) */
   imageUrl?: string;
+  /** TASK tiles: approved submissions required to complete the tile (1 = ordinary) */
+  quantity?: number;
   amount?: number;
 }
 
@@ -20,6 +22,7 @@ export interface IBoardTileLike {
   name?: string;
   description?: string;
   imageUrl?: string;
+  quantity?: number;
   amount?: number;
 }
 
@@ -39,6 +42,7 @@ export const toBoardTileInputs = (
             name: tile.name ?? '',
             description: tile.description,
             imageUrl: tile.imageUrl,
+            quantity: tile.quantity,
           },
         ];
       case 'GO_BACK':


### PR DESCRIPTION
Stacked on #25 — merge that first; GitHub retargets this to main automatically. Companion to sanguine-events #4 (the mechanics live there; merge the events side before this deploys).

## What

- The board builder's task editor gains a **"Drops needed"** field (default 1). Values above 1 mark the tile as counted; 1 keeps the payload clean (no `quantity` submitted).
- Counted tiles wear a small gold **×N** badge (builder and public board), and the public hover title says "(10 approved drops to complete)".
- Team progress needs no web changes: the events API bakes it into `currentTask` ("10 KBD heads (3/10)"), which the standings tables already render.
- Mock fixture gains a counted tile ("10 KBD heads") for offline dev.