### PR TITLE
Persist guessed tile images on save + events admin pending UI

### DIFF
--- a/app/components/TileImagePicker.tsx
+++ b/app/components/TileImagePicker.tsx
@@ -47,6 +47,7 @@ export function TileImagePicker({ value, onChange, id }: ITileImagePickerProps) 
   }, [trimmed]);
 
   const suggestions = trimmed.length < 2 ? [] : (fetcher.data?.results ?? []);
+  const searching = trimmed.length >= 2 && fetcher.state !== 'idle';
 
   const pick = (option: ITileImageOption) => {
     onChange(option.imageUrl);
@@ -113,6 +114,12 @@ export function TileImagePicker({ value, onChange, id }: ITileImagePickerProps) 
         aria-expanded={suggestions.length > 0}
         aria-autocomplete="list"
       />
+      {searching && (
+        <span
+          aria-hidden
+          className="absolute right-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 animate-spin rounded-full border-2 border-gray-500 border-t-transparent"
+        />
+      )}
       {suggestions.length > 0 && (
         <ul
           role="listbox"

--- a/app/components/button.tsx
+++ b/app/components/button.tsx
@@ -25,10 +25,23 @@ export interface ButtonProps
   extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: keyof typeof VARIANT_CLASSES;
   size?: keyof typeof SIZE_CLASSES;
+  /** Marks this button's action as in flight: disables it and shows a spinner. */
+  loading?: boolean;
 }
 
 const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant = 'default', size = 'sm', ...props }, ref) => (
+  (
+    {
+      className,
+      variant = 'default',
+      size = 'sm',
+      loading = false,
+      disabled,
+      children,
+      ...props
+    },
+    ref,
+  ) => (
     <button
       className={cn(
         'inline-flex cursor-pointer items-center justify-center whitespace-nowrap rounded-sm border transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-gray-400 disabled:cursor-not-allowed disabled:opacity-50',
@@ -37,8 +50,18 @@ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
         className,
       )}
       ref={ref}
+      disabled={disabled || loading}
+      aria-busy={loading || undefined}
       {...props}
-    />
+    >
+      {loading && (
+        <span
+          aria-hidden
+          className="mr-2 inline-block h-3.5 w-3.5 shrink-0 animate-spin rounded-full border-2 border-current border-t-transparent"
+        />
+      )}
+      {children}
+    </button>
   ),
 );
 Button.displayName = 'Button';

--- a/app/components/route-skeleton-loader.tsx
+++ b/app/components/route-skeleton-loader.tsx
@@ -5,7 +5,10 @@ import { useEffect } from 'react';
 
 function RouteSkeletonLoader() {
   const transition = useNavigation();
-  const busy = transition.state === 'loading';
+  // GET navigations only: after a form POST the same 'loading' state fires for
+  // the revalidation, and blanking the page there would stomp on the in-place
+  // pending UI (button spinners) the submitting screen is already showing.
+  const busy = transition.state === 'loading' && !transition.formData;
   const delayedPending = useSpinDelay(busy, {
     delay: 200,
     minDuration: 400,
@@ -89,6 +92,11 @@ function RouteSkeletonLoader() {
     // About page
     if (targetPath === '/about') {
       return <AboutSkeleton />;
+    }
+
+    // Events admin pages (/admin, /admin/tile-race)
+    if (targetPath.startsWith('/admin')) {
+      return <AdminSkeleton />;
     }
 
     // Home page
@@ -946,6 +954,61 @@ function AboutSkeleton() {
           ))}
         </Box>
       </div>
+    </Container>
+  );
+}
+
+// Admin Skeleton — mirrors the events admin layout: the brand/user chrome row
+// over the committed red rule, then a section heading with a prose line and
+// zebra rows carrying button-sized ghosts.
+function AdminSkeleton() {
+  return (
+    <Container size="4" className="min-h-full px-4 pt-3">
+      {/* Layout chrome: "Events admin" left; avatar, name, logout right */}
+      <Flex
+        align="center"
+        justify="between"
+        gap="3"
+        className="mb-6 border-b-2 border-b-sanguine-red pb-2"
+      >
+        <div className="h-5 w-28 animate-pulse rounded-sm bg-gray-800/50"></div>
+        <Flex align="center" gap="3">
+          <div className="h-6 w-6 animate-pulse rounded-sm bg-gray-800/50"></div>
+          <div className="h-4 w-24 animate-pulse rounded-sm bg-gray-800/50"></div>
+          <div className="h-8 w-20 animate-pulse rounded-sm border border-gray-800 bg-gray-900"></div>
+        </Flex>
+      </Flex>
+
+      {/* Section heading + right-aligned summary */}
+      <div className="flex items-baseline justify-between border-b border-gray-700 pb-1">
+        <div className="h-6 w-44 animate-pulse rounded-sm bg-gray-800/50"></div>
+        <div className="h-4 w-40 animate-pulse rounded-sm bg-gray-800/40"></div>
+      </div>
+
+      {/* Prose lede */}
+      <div className="mt-3 space-y-2.5">
+        <div className="h-4 w-full max-w-2xl animate-pulse rounded-sm bg-gray-800/50"></div>
+        <div className="h-4 w-3/4 max-w-xl animate-pulse rounded-sm bg-gray-800/50"></div>
+      </div>
+
+      {/* Rows with trailing button-sized ghosts */}
+      <Box className="mt-6">
+        {[...Array(5)].map((_, idx) => (
+          <Flex
+            key={idx}
+            align="center"
+            gap="3"
+            className={`border-b border-gray-800 px-2 py-3 ${idx % 2 === 1 ? 'bg-sanguine-red/[0.05]' : ''}`}
+          >
+            <div className="min-w-0 flex-1 space-y-1.5">
+              <div className="h-4 w-40 max-w-full animate-pulse rounded-sm bg-gray-800/50"></div>
+              <div className="h-3 w-56 max-w-full animate-pulse rounded-sm bg-gray-800/40"></div>
+            </div>
+            <div className="hidden h-8 w-24 animate-pulse rounded-sm border border-gray-800 bg-gray-900 sm:block"></div>
+            <div className="h-8 w-20 animate-pulse rounded-sm border border-gray-800 bg-gray-900"></div>
+          </Flex>
+        ))}
+      </Box>
     </Container>
   );
 }

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -78,14 +78,14 @@ const getRoster = async (): Promise<IPickerMember[]> => {
 export async function loader({ request }: LoaderFunctionArgs) {
   await requireStaff(request);
   try {
-    const race = await getAdminRace();
     // Channels feed the create form's pickers and name the dashboard's channel refs;
     // a Discord API hiccup degrades to raw ids rather than failing the page. Same
     // spirit for the roster: no roster just means the typeahead only takes raw ids.
-    const channels = await getGuildTextChannels().catch(
-      () => [] as IGuildTextChannel[],
-    );
-    const members = await getRoster().catch(() => [] as IPickerMember[]);
+    const [race, channels, members] = await Promise.all([
+      getAdminRace(),
+      getGuildTextChannels().catch(() => [] as IGuildTextChannel[]),
+      getRoster().catch(() => [] as IPickerMember[]),
+    ]);
     return json({ race, channels, members, apiError: null as string | null });
   } catch (e) {
     const message =
@@ -335,6 +335,18 @@ export default function AdminTileRace() {
 
 const fieldClass = 'flex flex-col gap-1.5';
 
+// Which page-level form action is in flight, if any. Covers the whole round
+// trip — action POST *and* the loader revalidation after it — so buttons stay
+// busy until the fresh data is actually on screen (navigation.state ===
+// 'submitting' alone re-enables them while the page is still refetching).
+// Per-row fetcher actions track their own fetcher instead.
+const usePendingIntent = (): string | null => {
+  const navigation = useNavigation();
+  return navigation.state !== 'idle' && navigation.formData
+    ? String(navigation.formData.get('intent') ?? '') || null
+    : null;
+};
+
 const classicBoardValid = (tiles: IBoardTileInput[]): boolean =>
   tiles.length > 0 &&
   tiles.every(tile => tile.type !== 'TASK' || (tile.name ?? '').trim());
@@ -364,8 +376,7 @@ function RaceModeSelect({
 
 function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
   const actionData = useActionData<typeof action>();
-  const navigation = useNavigation();
-  const submitting = navigation.state === 'submitting';
+  const submitting = usePendingIntent() === 'create';
   const [mode, setMode] = useState<RaceMode>('CLASSIC');
   const [tiles, setTiles] = useState<IBoardTileInput[]>([]);
   const [tiers, setTiers] = useState<IBoardTileInput[][]>([]);
@@ -484,7 +495,8 @@ function CreateRaceForm({ channels }: { channels: IGuildTextChannel[] }) {
             variant="primary"
             size="md"
             type="submit"
-            disabled={submitting || !boardValid}
+            loading={submitting}
+            disabled={!boardValid}
             className="w-fit"
           >
             {submitting ? 'Creating…' : 'Create race (draft)'}
@@ -533,8 +545,8 @@ function RaceDashboard({
   members: IPickerMember[];
 }) {
   const actionData = useActionData<typeof action>();
-  const navigation = useNavigation();
-  const submitting = navigation.state === 'submitting';
+  const pendingIntent = usePendingIntent();
+  const submitting = pendingIntent !== null;
   const { event, board, standings } = race;
   const finished = standings.filter(s => s.isFinished).length;
   const channelName = (id: string) =>
@@ -603,7 +615,11 @@ function RaceDashboard({
               className="w-24 text-lg"
             />
           </div>
-          <Button type="submit" disabled={submitting}>
+          <Button
+            type="submit"
+            disabled={submitting}
+            loading={pendingIntent === 'reschedule'}
+          >
             Update length
           </Button>
         </Form>
@@ -613,8 +629,15 @@ function RaceDashboard({
         {event.status === 'DRAFT' && (
           <Form method="post" className="mt-3">
             <input type="hidden" name="intent" value="start" />
-            <Button variant="primary" type="submit" disabled={submitting}>
-              Start race and roll first tasks
+            <Button
+              variant="primary"
+              type="submit"
+              disabled={submitting}
+              loading={pendingIntent === 'start'}
+            >
+              {pendingIntent === 'start'
+                ? 'Starting race…'
+                : 'Start race and roll first tasks'}
             </Button>
           </Form>
         )}
@@ -676,8 +699,13 @@ function RaceDashboard({
             }}
           >
             <input type="hidden" name="intent" value="end" />
-            <Button variant="gold" type="submit">
-              End race
+            <Button
+              variant="gold"
+              type="submit"
+              disabled={submitting}
+              loading={pendingIntent === 'end'}
+            >
+              {pendingIntent === 'end' ? 'Ending…' : 'End race'}
             </Button>
           </Form>
           <Form
@@ -692,8 +720,13 @@ function RaceDashboard({
             }}
           >
             <input type="hidden" name="intent" value="cancel" />
-            <Button variant="danger" type="submit">
-              Cancel race
+            <Button
+              variant="danger"
+              type="submit"
+              disabled={submitting}
+              loading={pendingIntent === 'cancel'}
+            >
+              {pendingIntent === 'cancel' ? 'Cancelling…' : 'Cancel race'}
             </Button>
           </Form>
         </Flex>
@@ -715,6 +748,11 @@ function TeamRow({
 }) {
   const fetcher = useFetcher<typeof action>();
   const busy = fetcher.state !== 'idle';
+  // Which of this row's actions is in flight — the clicked button gets the
+  // spinner while its siblings just disable.
+  const rowIntent = busy
+    ? String(fetcher.formData?.get('intent') ?? '') || null
+    : null;
   const raceRunning = raceStatus === 'ACTIVE';
   const [editing, setEditing] = useState(false);
 
@@ -772,14 +810,22 @@ function TeamRow({
                 <fetcher.Form method="post">
                   <input type="hidden" name="intent" value="complete" />
                   <input type="hidden" name="team" value={standing.name} />
-                  <Button type="submit" disabled={busy}>
+                  <Button
+                    type="submit"
+                    disabled={busy}
+                    loading={rowIntent === 'complete'}
+                  >
                     Complete task
                   </Button>
                 </fetcher.Form>
                 <fetcher.Form method="post">
                   <input type="hidden" name="intent" value="reroll" />
                   <input type="hidden" name="team" value={standing.name} />
-                  <Button type="submit" disabled={busy}>
+                  <Button
+                    type="submit"
+                    disabled={busy}
+                    loading={rowIntent === 'reroll'}
+                  >
                     Reroll
                   </Button>
                 </fetcher.Form>
@@ -800,7 +846,11 @@ function TeamRow({
                     }
                     className="h-9 w-24 px-2 py-0 text-base"
                   />
-                  <Button type="submit" disabled={busy}>
+                  <Button
+                    type="submit"
+                    disabled={busy}
+                    loading={rowIntent === 'move'}
+                  >
                     Move
                   </Button>
                 </fetcher.Form>
@@ -825,7 +875,12 @@ function TeamRow({
             >
               <input type="hidden" name="intent" value="removeteam" />
               <input type="hidden" name="team" value={standing.name} />
-              <Button variant="danger" type="submit" disabled={busy}>
+              <Button
+                variant="danger"
+                type="submit"
+                disabled={busy}
+                loading={rowIntent === 'removeteam'}
+              >
                 Remove
               </Button>
             </fetcher.Form>
@@ -878,9 +933,10 @@ function TeamRow({
                 variant="primary"
                 type="submit"
                 disabled={busy}
+                loading={rowIntent === 'editteam'}
                 className="w-fit"
               >
-                Save team
+                {rowIntent === 'editteam' ? 'Saving…' : 'Save team'}
               </Button>
             </fetcher.Form>
           </Table.Cell>
@@ -894,8 +950,7 @@ function TeamRow({
 // the API refuses board edits.
 function EditBoardSection({ board }: { board: IAdminTileRace['board'] }) {
   const actionData = useActionData<typeof action>();
-  const navigation = useNavigation();
-  const submitting = navigation.state === 'submitting';
+  const submitting = usePendingIntent() === 'updateboard';
   const [mode, setMode] = useState<RaceMode>(
     board.mode === 'TIERED' ? 'TIERED' : 'CLASSIC',
   );
@@ -962,7 +1017,8 @@ function EditBoardSection({ board }: { board: IAdminTileRace['board'] }) {
           <Button
             variant="primary"
             type="submit"
-            disabled={submitting || !boardValid}
+            loading={submitting}
+            disabled={!boardValid}
             className="w-fit"
           >
             {submitting ? 'Saving…' : 'Save board'}
@@ -982,8 +1038,7 @@ function EditBoardSection({ board }: { board: IAdminTileRace['board'] }) {
 
 function AddTeamForm({ members }: { members: IPickerMember[] }) {
   const actionData = useActionData<typeof action>();
-  const navigation = useNavigation();
-  const submitting = navigation.state === 'submitting';
+  const submitting = usePendingIntent() === 'addteam';
 
   return (
     <Box mt="4" className="max-w-xl">
@@ -1017,10 +1072,10 @@ function AddTeamForm({ members }: { members: IPickerMember[] }) {
         <Button
           variant="primary"
           type="submit"
-          disabled={submitting}
+          loading={submitting}
           className="w-fit"
         >
-          Add team
+          {submitting ? 'Adding…' : 'Add team'}
         </Button>
       </Form>
     </Box>

--- a/app/routes/admin.tile-race.tsx
+++ b/app/routes/admin.tile-race.tsx
@@ -48,6 +48,7 @@ import {
   toTierInputs,
 } from '~/utils/tile-race-board';
 import type { RaceMode } from '~/services/tile-race-service.server';
+import { getTileImageUrl } from '~/utils/tile-race-images';
 import { Input } from '~/components/input';
 import { Label } from '~/components/label';
 import { IPickerMember, MemberPicker } from '~/components/MemberPicker';
@@ -98,6 +99,17 @@ export async function loader({ request }: LoaderFunctionArgs) {
   }
 }
 
+// A TASK tile the admin left imageless gets the keyword-guessed artwork
+// persisted at save time — the Discord bot only renders explicit images, and
+// readers of the saved board shouldn't have to re-run the matcher.
+const withGuessedImage = (tile: IBoardTileInput): IBoardTileInput =>
+  tile.type === 'TASK' && !tile.imageUrl
+    ? {
+        ...tile,
+        imageUrl: getTileImageUrl(tile.name, tile.description) ?? undefined,
+      }
+    : tile;
+
 // The board builder submits its tiles (classic: flat list; tiered: nested tier
 // lists) as JSON in a hidden input, with the mode alongside. Structural checks
 // live here; board legality is the events API's call.
@@ -118,7 +130,13 @@ const parseBoardInput = (
     ) {
       return { errors: ['Every tier needs at least one tile.'] };
     }
-    return { board: { tiers: parsed as IBoardTileInput[][] } };
+    return {
+      board: {
+        tiers: (parsed as IBoardTileInput[][]).map(tier =>
+          tier.map(withGuessedImage),
+        ),
+      },
+    };
   }
   if (!Array.isArray(parsed) || !parsed.length) {
     return { errors: ['Add at least one tile to the board.'] };
@@ -126,7 +144,7 @@ const parseBoardInput = (
   return {
     board: {
       diceSides: Number(formData.get('diceSides') ?? 6),
-      tiles: parsed as IBoardTileInput[],
+      tiles: (parsed as IBoardTileInput[]).map(withGuessedImage),
     },
   };
 };


### PR DESCRIPTION
## What

**Persist the keyword-guessed tile image when the board is saved** — the board builder fuzzy-matches wiki artwork for imageless TASK tiles, but that guess only lived client-side, so the Discord bot (which only renders explicit `imageUrl`s) never showed it. Board saves (create + edit, classic + tiered) now stamp the guessed image into the tile before it reaches the events API. Tiles with an explicitly picked image are untouched, and the guessed URLs are wiki-hosted so they pass the API's `imageUrl` validation.

**Pending UI across the events admin** —
- `Button` gains a `loading` prop (spinner + disable + `aria-busy`), wired per-intent so the clicked button spins while siblings just disable; covers the full round trip including loader revalidation
- Admin routes get a matching route skeleton, GET navigations only, so post-submit revalidation doesn't blank the in-place pending UI
- The tile image picker shows a search spinner while suggestions load
- Admin loader fetches race/channels/roster with `Promise.all`

## Notes

Once saved, a guessed image is indistinguishable from a picked one: re-opening the draft shows it as a selected chip, and renaming the task won't re-guess until the chip is cleared.