### PR TITLE
Refuse to mint sessions for non-staff Discord logins

### DIFF
--- a/app/mocks/auth.server.ts
+++ b/app/mocks/auth.server.ts
@@ -3,6 +3,9 @@ import type { ISessionUser } from '../services/auth.server';
 
 // MOCK_MODE stand-in for Discord OAuth: every visitor is a logged-in staff member.
 
+// Keep the exported surface in sync with the real module (login.tsx imports this).
+export const NOT_STAFF_MESSAGE = 'not-staff';
+
 const mockUser: ISessionUser = {
   discordId: '111111111111111111',
   username: 'MockAdmin',

--- a/app/routes/login.tsx
+++ b/app/routes/login.tsx
@@ -5,6 +5,7 @@ import { Button } from '~/components/button';
 import {
   authenticator,
   getSessionUser,
+  NOT_STAFF_MESSAGE,
   sessionStorage,
 } from '~/services/auth.server';
 import { PageHeader } from '~/components/PageHeader';
@@ -16,15 +17,23 @@ export async function loader({ request }: LoaderFunctionArgs) {
   if (user?.isStaff) {
     throw redirect('/admin');
   }
-  const denied = new URL(request.url).searchParams.has('denied');
   // remix-auth flashes the failure reason into the session on failureRedirect —
-  // surface it instead of silently looping back to the sign-in button.
+  // surface it instead of silently looping back to the sign-in button. Non-staff
+  // logins throw the NOT_STAFF_MESSAGE sentinel (no session is minted for them),
+  // which renders as the denied copy rather than a generic OAuth failure.
   const session = await sessionStorage.getSession(request.headers.get('Cookie'));
   const flashed = session.get(authenticator.sessionErrorKey) as
     | { message?: string }
     | undefined;
+  const denied =
+    new URL(request.url).searchParams.has('denied') ||
+    flashed?.message === NOT_STAFF_MESSAGE;
+  const authError =
+    flashed?.message && flashed.message !== NOT_STAFF_MESSAGE
+      ? flashed.message
+      : null;
   return json(
-    { denied, authError: flashed?.message ?? null },
+    { denied, authError },
     { headers: { 'Set-Cookie': await sessionStorage.commitSession(session) } },
   );
 }

--- a/app/services/auth.server.ts
+++ b/app/services/auth.server.ts
@@ -6,9 +6,12 @@ import { getGuildMember } from '~/services/discord-admin-service.server';
 import { audit } from '~/services/audit.server';
 
 /**
- * Discord OAuth for the admin portal. Anyone can complete the login; authorization
- * is the staff-role check (the same roles the events bot honors), stamped into the
- * session at login time. requireStaff gates every /admin loader and action.
+ * Discord OAuth for the admin portal. Anyone can complete Discord's side of the
+ * dance (OAuth providers don't know about guild roles), but the verify callback
+ * refuses to mint a session for non-staff — the staff-role check (the same roles
+ * the events bot honors) throws NOT_STAFF_MESSAGE, remix-auth bounces to the
+ * failureRedirect, and no cookie is ever written. requireStaff still gates every
+ * /admin loader and action as defense in depth.
  */
 export interface ISessionUser {
   discordId: string;
@@ -46,6 +49,10 @@ const staffRoleIds = [
   process.env.EVENT_TEAM_ROLE_ID,
 ].filter((id): id is string => !!id);
 
+// Sentinel carried through remix-auth's error flash so /login can tell "wrong
+// role" apart from a genuinely failed OAuth exchange.
+export const NOT_STAFF_MESSAGE = 'not-staff';
+
 export const authenticator = new Authenticator<ISessionUser>(sessionStorage);
 
 authenticator.use(
@@ -66,6 +73,9 @@ authenticator.use(
         const username = member?.nick ?? profile.displayName;
         const avatarHash = profile.__json.avatar;
         audit('auth.login', { discordId: profile.id, username, isStaff });
+        if (!isStaff) {
+          throw new Error(NOT_STAFF_MESSAGE);
+        }
         return {
           discordId: profile.id,
           username,
@@ -75,6 +85,10 @@ authenticator.use(
           isStaff,
         };
       } catch (error) {
+        // The denied path is already audited above as auth.login with isStaff:false.
+        if (error instanceof Error && error.message === NOT_STAFF_MESSAGE) {
+          throw error;
+        }
         // remix-auth turns this into a failureRedirect; make sure the real cause
         // also lands in the server log.
         audit('auth.login_failed', {
@@ -87,7 +101,12 @@ authenticator.use(
   ),
 );
 
-/** The logged-in staff member, or a redirect to /login (with ?denied for non-staff). */
+/**
+ * The logged-in staff member, or a redirect to /login (with ?denied for non-staff).
+ * Non-staff sessions are no longer minted at login, so the isStaff branch is
+ * defense in depth: it covers sessions issued before that change and any future
+ * regression in the verify callback.
+ */
 export const requireStaff = async (request: Request): Promise<ISessionUser> => {
   const user = await authenticator.isAuthenticated(request);
   if (!user) {


### PR DESCRIPTION
## What

Anyone can complete Discord's side of the OAuth dance (providers don't know about guild roles), but the admin portal no longer issues its own session cookie unless the account holds an event staff role.

- **`auth.server.ts`**: the verify callback throws a `NOT_STAFF_MESSAGE` sentinel when the role check fails, so remix-auth hits the failure redirect and never writes `__sanguine_admin`. The denied login is still audited (`auth.login` with `isStaff: false`) without double-logging as `auth.login_failed`.
- **`login.tsx`**: the flashed sentinel renders as the existing "doesn't hold an event staff role" copy instead of a generic OAuth failure; real OAuth errors still surface via `authError`.
- **`mocks/auth.server.ts`**: exports the sentinel so the MOCK_MODE alias keeps the same module surface.

`requireStaff` keeps its `isStaff` check as defense in depth — it covers sessions minted before this change and any future regression in the verify callback.

## Testing

- `npm run lint` and `npm run typecheck` pass.
- Manual check: sign in with a non-staff Discord account → back on `/login` with the denied message and no `__sanguine_admin` cookie.