### PR TITLE
Add infernal cape to untradeable items list

### DIFF
--- a/app/utils/untradable-items.ts
+++ b/app/utils/untradable-items.ts
@@ -153,4 +153,7 @@ export const untradeableItems: Record<number, string> = {
 
   33634: 'elder venator fang',
   33631: 'crimson kisten',
+
+  // Inferno reward (untradeable)
+  21295: 'infernal cape',
 };


### PR DESCRIPTION
Infernal cape is now worth points, so it needs an entry in the untradeables map (id 21295) to resolve to a named item with the standard wiki detail icon.